### PR TITLE
Fix for issue #23, #33, #218

### DIFF
--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -185,7 +185,7 @@ contract Cooler {
 
         loanID = loans.length;
         loans.push(
-            Loan(req, req.amount + interest, 0, collat, expiration, msg.sender)
+            Loan(req, req.amount + interest, collat, expiration, true, msg.sender)
         );
         debt.transferFrom(msg.sender, owner, req.amount);
     }

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -185,7 +185,7 @@ contract Cooler {
 
         loanID = loans.length;
         loans.push(
-            Loan(req, req.amount + interest, 0, collat, expiration, true, msg.sender)
+            Loan(req, req.amount + interest, 0, collat, expiration, msg.sender)
         );
         debt.transferFrom(msg.sender, owner, req.amount);
     }


### PR DESCRIPTION
Issue details: https://github.com/sherlock-audit/2023-01-cooler-judging/issues/23

Changes:
- Add repaid uint256 in Loan data
- Increment repaid upon calling repay()
- Transfer debt tokens to Cooler (not lender) upon calling repay()
- Add function to transfer repaid debt tokens to lender, setting repaid to zero
- Set repayment amount to debt amount when repaid > loan.amount (prevents repayment greater than debt)
- No longer delete loan data upon full repayment (loan.lender must always be known to claim repayment)