### PR TITLE
Fix for issue #320

### DIFF
--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -143,7 +143,8 @@ contract Cooler {
         loan.expiry += req.duration;
         loan.collateral += newCollateral;
         
-        collateral.transferFrom(msg.sender, address(this), newCollateral);
+        if (newCollateral > 0)
+            collateral.transferFrom(msg.sender, address(this), newCollateral);
     }
 
     /// @notice delegate voting power on collateral


### PR DESCRIPTION
Prevents revert on roll() when 0 new collateral is transferred for some tokens by only transferring tokens if newCollateral is greater than 0. Does not address issue of free rollover (and as a result, preventing lender from calling default() on the loan). This is addressed in the fix to issues #215/#265 dealing with auto rolling. Issue details: sherlock-audit/2023-01-cooler-judging#320