### PR TITLE
Fix for issue #263

### DIFF
--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -14,6 +14,7 @@ contract Cooler {
     error Default();
     error NoDefault();
     error NotRollable();
+    error ZeroCollateralReturned();
 
     // Data Structures
 
@@ -112,6 +113,8 @@ contract Cooler {
             revert Default();
         
         uint256 decollateralized = loan.collateral * repaid / loan.amount;
+        if (decollateralized == 0)
+            revert ZeroCollateralReturned();
 
         if (repaid == loan.amount) delete loans[loanID];
         else {


### PR DESCRIPTION
Revert upon repayment if amount of collateral returned is zero. Ensures against underflow if loan.collateral and collateralFor(loan) diverge. 
Issue details: https://github.com/sherlock-audit/2023-01-cooler-judging/issues/263