### PR TITLE
Fix for issue #215, #265

### DIFF
--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -32,7 +32,6 @@ contract Cooler {
         uint256 amount; // the amount of debt owed,
         uint256 collateral; // the amount of collateral pledged,
         uint256 expiry; // the time when the loan defaults,
-        bool rollable; // whether the loan can be rolled over,
         address lender; // and the lender's address.
     }
 
@@ -133,7 +132,7 @@ contract Cooler {
         if (block.timestamp > loan.expiry) 
             revert Default();
 
-        if (!loan.rollable)
+        if (!loan.request.active)
             revert NotRollable();
 
         uint256 newCollateral = collateralFor(loan.amount, req.loanToCollateral) - loan.collateral;
@@ -174,22 +173,28 @@ contract Cooler {
 
         loanID = loans.length;
         loans.push(
-            Loan(req, req.amount + interest, collat, expiration, true, msg.sender)
+            Loan(req, req.amount + interest, collat, expiration, msg.sender)
         );
         debt.transferFrom(msg.sender, owner, req.amount);
     }
 
-    /// @notice change 'rollable' status of loan
+    /// @notice provide terms for loan to roll over
     /// @param loanID index of loan in loans[]
-    /// @return bool new 'rollable' status
-    function toggleRoll(uint256 loanID) external returns (bool) {
+    /// @param interest to pay (annualized % of 'amount')
+    /// @param loanToCollateral debt tokens per collateral token pledged
+    /// @param duration of loan tenure in seconds
+    function provideNewTermsForRoll (
+        uint256 loanID, 
+        uint256 interest,
+        uint256 loanToCollateral,
+        uint256 duration
+    ) external {
         Loan storage loan = loans[loanID];
 
         if (msg.sender != loan.lender)
             revert OnlyApproved();
 
-        loan.rollable = !loan.rollable;
-        return loan.rollable;
+        loan.request = Request(loan.amount, interest, loanToCollateral, duration, true);
     }
 
     /// @notice send collateral to lender upon default


### PR DESCRIPTION
Precede loan rollover with lender providing new terms to ensure: 1) loan cannot be rolled over ad infinitum; 2) loan cannot be rolled over without lenders consent. Accomplish this by treating already-stored request terms as rollover terms. request.active is set to false upon clear(), and not set to true (allowing rollover) until lender calls provideNewTermsForRoll() and provides rollover terms. 
Issue #215 details: https://github.com/sherlock-audit/2023-01-cooler-judging/issues/215 
Issue #265 details: https://github.com/sherlock-audit/2023-01-cooler-judging/issues/265