### PR TITLE
Integrate Cooler Clearinghouse as a Default Framework Policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/out
+/cache
+.env

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/openzeppelin-contracts"]
     path = lib/openzeppelin-contracts
     url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/olympus-v3"]
+	path = lib/olympus-v3
+	url = https://github.com/OlympusDAO/olympus-v3

--- a/src/ClearingHouse.sol
+++ b/src/ClearingHouse.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import "src/Factory.sol";
 import {ROLESv1, RolesConsumer} from "lib/olympus-v3/src/modules/ROLES/OlympusRoles.sol";
 import {TRSRYv1, ERC20 as TRSRYERC20} from "lib/olympus-v3/src/modules/TRSRY/TRSRY.v1.sol";
-import {Kernel, Policy, Keycode, toKeycode} from "lib/olympus-v3/src/Kernel.sol";
+import {Kernel, Policy, Keycode, toKeycode, Permissions} from "lib/olympus-v3/src/Kernel.sol";
 
 contract ClearingHouse is Policy, RolesConsumer {
     // Errors
@@ -54,6 +54,11 @@ contract ClearingHouse is Policy, RolesConsumer {
 
         TRSRY = TRSRYv1(getModuleAddress(toKeycode("TRSRY")));
         ROLES = ROLESv1(getModuleAddress(toKeycode("ROLES")));
+    }
+
+    function requestPermissions() external view override returns (Permissions[] memory requests) {
+        requests = new Permissions[](1);
+        requests[0] = Permissions(toKeycode("TRSRY"), TRSRY.withdrawReserves.selector);
     }
 
     // Operation

--- a/src/aux/ClearingHouse.sol
+++ b/src/aux/ClearingHouse.sol
@@ -1,136 +1,136 @@
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+// // SPDX-License-Identifier: MIT
+// pragma solidity ^0.8.0;
 
-import "../Factory.sol";
-import "../lib/mininterfaces.sol";
+// import "../Factory.sol";
+// import "../lib/mininterfaces.sol";
 
-contract ClearingHouse {
-    // Errors
+// contract ClearingHouse {
+//     // Errors
 
-    error OnlyApproved();
-    error OnlyFromFactory();
-    error BadEscrow();
-    error InterestMinimum();
-    error LTCMaximum();
-    error DurationMaximum();
+//     error OnlyApproved();
+//     error OnlyFromFactory();
+//     error BadEscrow();
+//     error InterestMinimum();
+//     error LTCMaximum();
+//     error DurationMaximum();
 
-    // Roles
+//     // Roles
 
-    address public operator;
-    address public overseer;
-    address public pendingOperator;
-    address public pendingOverseer;
+//     address public operator;
+//     address public overseer;
+//     address public pendingOperator;
+//     address public pendingOverseer;
 
-    // Relevant Contracts
+//     // Relevant Contracts
 
-    ERC20 public immutable dai;
-    ERC20 public immutable gOHM;
-    address public immutable treasury;
-    CoolerFactory public immutable factory;
+//     ERC20 public immutable dai;
+//     ERC20 public immutable gOHM;
+//     address public immutable treasury;
+//     CoolerFactory public immutable factory;
 
-    // Parameter Bounds
+//     // Parameter Bounds
 
-    uint256 public constant minimumInterest = 2e16; // 2%
-    uint256 public constant maxLTC = 2_500 * 1e18; // 2,500
-    uint256 public constant maxDuration = 365 days; // 1 year
+//     uint256 public constant minimumInterest = 2e16; // 2%
+//     uint256 public constant maxLTC = 2_500 * 1e18; // 2,500
+//     uint256 public constant maxDuration = 365 days; // 1 year
 
-    constructor (
-        address oper, 
-        address over, 
-        ERC20 g, 
-        ERC20 d, 
-        CoolerFactory f, 
-        address t
-    ) {
-        operator = oper;
-        overseer = over;
-        gOHM = g;
-        dai = d;
-        factory = f;
-        treasury = t;
-    }
+//     constructor (
+//         address oper, 
+//         address over, 
+//         ERC20 g, 
+//         ERC20 d, 
+//         CoolerFactory f, 
+//         address t
+//     ) {
+//         operator = oper;
+//         overseer = over;
+//         gOHM = g;
+//         dai = d;
+//         factory = f;
+//         treasury = t;
+//     }
 
-    // Operation
+//     // Operation
 
-    /// @notice clear a requested loan
-    /// @param cooler contract requesting loan
-    /// @param id of loan in escrow contract
-    function clear (Cooler cooler, uint256 id) external returns (uint256) {
-        if (msg.sender != operator) 
-            revert OnlyApproved();
+//     /// @notice clear a requested loan
+//     /// @param cooler contract requesting loan
+//     /// @param id of loan in escrow contract
+//     function clear (Cooler cooler, uint256 id) external returns (uint256) {
+//         if (msg.sender != operator) 
+//             revert OnlyApproved();
 
-        // Validate escrow
-        if (!factory.created(address(cooler))) 
-            revert OnlyFromFactory();
-        if (cooler.collateral() != gOHM || cooler.debt() != dai)
-            revert BadEscrow();
+//         // Validate escrow
+//         if (!factory.created(address(cooler))) 
+//             revert OnlyFromFactory();
+//         if (cooler.collateral() != gOHM || cooler.debt() != dai)
+//             revert BadEscrow();
 
-        (
-            uint256 amount, 
-            uint256 interest, 
-            uint256 ltc, 
-            uint256 duration,
-        ) = cooler.requests(id);
+//         (
+//             uint256 amount, 
+//             uint256 interest, 
+//             uint256 ltc, 
+//             uint256 duration,
+//         ) = cooler.requests(id);
 
-        // Validate terms
-        if (interest < minimumInterest) 
-            revert InterestMinimum();
-        if (ltc > maxLTC) 
-            revert LTCMaximum();
-        if (duration > maxDuration) 
-            revert DurationMaximum();
+//         // Validate terms
+//         if (interest < minimumInterest) 
+//             revert InterestMinimum();
+//         if (ltc > maxLTC) 
+//             revert LTCMaximum();
+//         if (duration > maxDuration) 
+//             revert DurationMaximum();
 
-        // Clear loan
-        dai.approve(address(cooler), amount);
-        return cooler.clear(id);
-    }
+//         // Clear loan
+//         dai.approve(address(cooler), amount);
+//         return cooler.clear(id);
+//     }
 
-    /// @notice toggle 'rollable' status of a loan
-    function toggleRoll(Cooler cooler, uint256 loanID) external {
-        if (msg.sender != operator) 
-            revert OnlyApproved();
+//     /// @notice toggle 'rollable' status of a loan
+//     function toggleRoll(Cooler cooler, uint256 loanID) external {
+//         if (msg.sender != operator) 
+//             revert OnlyApproved();
 
-        cooler.toggleRoll(loanID);
-    }
+//         cooler.toggleRoll(loanID);
+//     }
 
-    // Oversight
+//     // Oversight
 
-    /// @notice pull funding from treasury
-    function fund (uint256 amount) external {
-        if (msg.sender != overseer) 
-            revert OnlyApproved();
-        ITreasury(treasury).manage(address(dai), amount);
-    }
+//     /// @notice pull funding from treasury
+//     function fund (uint256 amount) external {
+//         if (msg.sender != overseer) 
+//             revert OnlyApproved();
+//         ITreasury(treasury).manage(address(dai), amount);
+//     }
 
-    /// @notice return funds to treasury
-    /// @param token to transfer
-    /// @param amount to transfer
-    function defund (ERC20 token, uint256 amount) external {
-        if (msg.sender != operator && msg.sender != overseer) 
-            revert OnlyApproved();
-        token.transfer(treasury, amount);
-    }
+//     /// @notice return funds to treasury
+//     /// @param token to transfer
+//     /// @param amount to transfer
+//     function defund (ERC20 token, uint256 amount) external {
+//         if (msg.sender != operator && msg.sender != overseer) 
+//             revert OnlyApproved();
+//         token.transfer(treasury, amount);
+//     }
 
-    // Management
+//     // Management
 
-    /// @notice operator or overseer can set a new address
-    /// @dev using a push/pull model for safety
-    function push (address newAddress) external {
-        if (msg.sender == overseer) 
-            pendingOverseer = newAddress;
-        else if (msg.sender == operator) 
-            pendingOperator = newAddress;
-        else revert OnlyApproved();
-    }
+//     /// @notice operator or overseer can set a new address
+//     /// @dev using a push/pull model for safety
+//     function push (address newAddress) external {
+//         if (msg.sender == overseer) 
+//             pendingOverseer = newAddress;
+//         else if (msg.sender == operator) 
+//             pendingOperator = newAddress;
+//         else revert OnlyApproved();
+//     }
 
-    /// @notice new operator or overseer can pull role once pushed
-    function pull () external {
-        if (msg.sender == pendingOverseer) {
-            overseer = pendingOverseer;
-            pendingOverseer = address(0);
-        } else if (msg.sender == pendingOperator) {
-            operator = pendingOperator;
-            pendingOperator = address(0);
-        } else revert OnlyApproved();
-    }
-}
+//     /// @notice new operator or overseer can pull role once pushed
+//     function pull () external {
+//         if (msg.sender == pendingOverseer) {
+//             overseer = pendingOverseer;
+//             pendingOverseer = address(0);
+//         } else if (msg.sender == pendingOperator) {
+//             operator = pendingOperator;
+//             pendingOperator = address(0);
+//         } else revert OnlyApproved();
+//     }
+// }

--- a/src/test/LendTest.t.sol
+++ b/src/test/LendTest.t.sol
@@ -144,12 +144,10 @@ contract ContractTest is DSTest {
     }
 
     function test_clear() public {
-        setUp();
         clear(request());
     }
 
     function test_repay() public {
-        setUp();
         uint loanID = clear(request());
 
         // Test repay
@@ -165,22 +163,18 @@ contract ContractTest is DSTest {
     }
 
     function test_roll() public {
-        setUp();
         roll(clear(request()));
     }
     
     function test_default() public {
-        setUp();
         processDefault(clear(request()));
     }
 
     function test_defunding() public {
-        setUp();
         withdrawTokens();
     }
 
     function test_funding() public {
-        setUp();
         uint balance = dai.balanceOf(address(clearinghouse));
         uint last = clearinghouse.lastFunded();
 
@@ -200,9 +194,7 @@ contract ContractTest is DSTest {
         assertTrue(balance + budget[2] == dai.balanceOf(address(clearinghouse)));
     }
 
-    /// @dev sorry I am not great with testing syntax
-    function test_shouldFail_notRollable() public {
-        setUp();
+    function testFail_shouldFail_notRollable() public {
         uint loanID = clear(request());
 
         clearinghouse.toggleRoll(cooler, loanID);


### PR DESCRIPTION
In order to successfully integrate with the Olympus v3 Treasury, the ClearingHouse must be installed in the Kernel as a Policy contract. This provides various conveniences, including access to updated TRSRY addresses through module upgrades without redeploying and ability to leverage the built-in roles-based authentication instead of localized permissions for protected functions.

Therefore, I've made the following updates:
- Removed treasury constructor variable in exchange for the Default style dependency.
- Requested permission to use the `withdrawReserves` function on the TRSRY module.
- Removed the local "overseer" role in exchange for the systems role-based access control.