### PR TITLE
test: reentrancy attacks

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,0 +1,2 @@
+LockTest:test_smartLock() (gas: 7940)
+LockTest:test_stdLock() (gas: 7672)

--- a/src/ClearingHouse.sol
+++ b/src/ClearingHouse.sol
@@ -270,4 +270,11 @@ contract ClearingHouse is Policy, RolesConsumer, CoolerCallback {
         uint256 interest = loan * interestPercent / 1e18;
         return loan + interest;
     }
+    
+    /// @notice view function to compute the interest for a given debt amount.
+    /// @param debt_ amount of gOHM.
+    function interestFromDebt(uint256 debt_) public pure returns (uint256) {
+        uint256 interestPercent = (INTEREST_RATE * DURATION) / 365 days;
+        return debt_ * interestPercent / 1e18;
+    }
 }

--- a/src/ClearingHouse.sol
+++ b/src/ClearingHouse.sol
@@ -183,20 +183,10 @@ contract ClearingHouse is Policy, RolesConsumer, CoolerCallback {
 
     // --- CALLBACKS -----------------------------------------------------
 
-    /// @notice Unused callback since rollLoan() is handled by the clearinghouse.
-    /// @dev Overriden and left empty to save gas.
-    function _onRoll(uint256, uint256, uint256) internal override {}
-
-    /// @notice Unused callback since defaults are handled by the clearinghouse.
-    /// @dev Overriden and left empty to save gas.
-    function _onDefault(uint256, uint256, uint256) internal override {}
-
-    /// @notice Callback to decrement loan receivables.
-    /// *unused loadID_ of the load.
+    /// @notice Overridden callback to decrement loan receivables.
+    /// @param *unused loadID_ of the load.
     /// @param amount_ repaid (in DAI).
     function _onRepay(uint256, uint256 amount_) internal override {
-        _onlyFromFactory();   // Validate caller is a Cooler deployed by the factory.
-
         dai.approve(address(sDai), amount_);
         uint256 interest = interestFromDebt(amount_);
         // Sweep into DSR. Keep amount lent.

--- a/src/ClearingHouse.sol
+++ b/src/ClearingHouse.sol
@@ -270,11 +270,4 @@ contract ClearingHouse is Policy, RolesConsumer, CoolerCallback {
         uint256 interest = loan * interestPercent / 1e18;
         return loan + interest;
     }
-    
-    /// @notice view function to compute the interest for a given debt amount.
-    /// @param debt_ amount of gOHM.
-    function interestFromDebt(uint256 debt_) public pure returns (uint256) {
-        uint256 interestPercent = (INTEREST_RATE * DURATION) / 365 days;
-        return debt_ * interestPercent / 1e18;
-    }
 }

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -215,8 +215,10 @@ contract Cooler is Clone {
         bool isCallback_
     ) external returns (uint256 loanID) {
         Request storage req = requests[reqID_];
+
         // Ensure lender implements the CoolerCallback abstract
-        if (isCallback_) if (!CoolerCallback(msg.sender).isCoolerCallback()) revert NotCoolerCallback();
+        if (isCallback_ && !CoolerCallback(msg.sender).isCoolerCallback()) revert NotCoolerCallback();
+
         // Ensure loan request is active. 
         if (!req.active) revert Deactivated();
 

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -192,7 +192,7 @@ contract Cooler is Clone {
             collateral().safeTransferFrom(msg.sender, address(this), newCollateral);
         }
 
-        if (loan.callback) CoolerCallback(loan.lender).onRoll(loanID_);
+        if (loan.callback) CoolerCallback(loan.lender).onRoll(loanID_, newDebt, newCollateral);
     }
 
     /// @notice Delegate voting power on collateral.
@@ -281,7 +281,7 @@ contract Cooler is Clone {
     /// @notice Claim collateral upon loan default.
     /// @param loanID_ index of loan in loans[]
     /// @return uint256 collateral amount.
-    function claimDefaulted(uint256 loanID_) external returns (uint256) {
+    function claimDefaulted(uint256 loanID_) external returns (uint256, uint256) {
         Loan memory loan = loans[loanID_];
         delete loans[loanID_];
 
@@ -290,7 +290,7 @@ contract Cooler is Clone {
         collateral().safeTransfer(loan.lender, loan.collateral);
 
         if (loan.callback) CoolerCallback(loan.lender).onDefault(loanID_, loan.amount, loan.collateral);
-        return loan.collateral;
+        return (loan.amount, loan.collateral);
     }
 
     /// @notice Approve transfer of loan ownership rights to a new address.

--- a/src/CoolerCallback.sol
+++ b/src/CoolerCallback.sol
@@ -26,12 +26,6 @@ abstract contract CoolerCallback {
         require(factory.created(msg.sender), "ONLY_FROM_FACTORY");
     }
 
-    /// @notice Callback function that handles defaults.
-    function onDefault(uint256 loanID, uint256 amount, uint256 collateral) external virtual {
-        _onlyFromFactory();
-        // Callback Logic
-    }
-
     /// @notice Callback function that handles repayments.
     function onRepay(uint256 loanID, uint256 amount) external virtual { 
         _onlyFromFactory();
@@ -39,7 +33,13 @@ abstract contract CoolerCallback {
     }
 
     /// @notice Callback function that handles rollovers.
-    function onRoll(uint256 loanID) external virtual {
+    function onRoll(uint256 loanID, uint256 newDebt, uint256 newCollateral) external virtual {
+        _onlyFromFactory();
+        // Callback Logic
+    }
+
+    /// @notice Callback function that handles defaults.
+    function onDefault(uint256 loanID, uint256 debt, uint256 collateral) external virtual {
         _onlyFromFactory();
         // Callback Logic
     }

--- a/src/CoolerCallback.sol
+++ b/src/CoolerCallback.sol
@@ -7,39 +7,63 @@ import {CoolerFactory} from "src/CoolerFactory.sol";
 /// @dev    The three callback functions must be implemented if `isCoolerCallback()` is set to true.
 abstract contract CoolerCallback {
 
+    // --- ERRORS ----------------------------------------------------
+
+    error OnlyFromFactory();
+
+    // --- INITIALIZATION --------------------------------------------
+
     CoolerFactory public immutable factory;
 
     constructor(address coolerFactory_) {
         factory = CoolerFactory(coolerFactory_);
     }
 
+    // --- EXTERNAL FUNCTIONS ------------------------------------------------
+
     /// @notice Informs to Cooler that this contract can handle its callbacks.
     function isCoolerCallback() external pure returns (bool) {
         return true;
     }
 
+    /// @notice Callback function that handles repayments.
+    function onRepay(uint256 loanID, uint256 amount) external { 
+        _onRepay(loanID, amount);
+    }
+
+    /// @notice Callback function that handles rollovers.
+    function onRoll(uint256 loanID, uint256 newDebt, uint256 newCollateral) external {
+        _onRoll(loanID, newDebt, newCollateral);
+    }
+
+    /// @notice Callback function that handles defaults.
+    function onDefault(uint256 loanID, uint256 debt, uint256 collateral) external {
+        _onDefault(loanID, debt, collateral);
+    }
+
+    // --- INTERNAL FUNCTIONS ------------------------------------------------
+
     /// @dev Ensures that the callback caller is a Cooler deployed by the factory.
     ///      Failing to implement this check properly may lead to unexpected/malicious
     ///      contracts calling the lender's callback functions.
-    function _onlyFromFactory() internal view {
-        // Validate caller is cooler.
-        require(factory.created(msg.sender), "ONLY_FROM_FACTORY");
+    function _onlyFromFactory() internal view virtual {
+        if(!factory.created(msg.sender)) revert OnlyFromFactory();
     }
 
     /// @notice Callback function that handles repayments.
-    function onRepay(uint256 loanID, uint256 amount) external virtual { 
+    function _onRepay(uint256 loanID, uint256 amount) internal virtual { 
         _onlyFromFactory();
         // Callback Logic
     }
 
     /// @notice Callback function that handles rollovers.
-    function onRoll(uint256 loanID, uint256 newDebt, uint256 newCollateral) external virtual {
+    function _onRoll(uint256 loanID, uint256 newDebt, uint256 newCollateral) internal virtual {
         _onlyFromFactory();
         // Callback Logic
     }
 
     /// @notice Callback function that handles defaults.
-    function onDefault(uint256 loanID, uint256 debt, uint256 collateral) external virtual {
+    function _onDefault(uint256 loanID, uint256 debt, uint256 collateral) internal virtual {
         _onlyFromFactory();
         // Callback Logic
     }

--- a/src/CoolerCallback.sol
+++ b/src/CoolerCallback.sol
@@ -27,44 +27,31 @@ abstract contract CoolerCallback {
     }
 
     /// @notice Callback function that handles repayments.
-    function onRepay(uint256 loanID, uint256 amount) external { 
-        _onRepay(loanID, amount);
+    function onRepay(uint256 loanID_, uint256 amount_) external { 
+        if(!factory.created(msg.sender)) revert OnlyFromFactory();
+        _onRepay(loanID_, amount_);
     }
 
     /// @notice Callback function that handles rollovers.
-    function onRoll(uint256 loanID, uint256 newDebt, uint256 newCollateral) external {
-        _onRoll(loanID, newDebt, newCollateral);
+    function onRoll(uint256 loanID_, uint256 newDebt, uint256 newCollateral) external {
+        if(!factory.created(msg.sender)) revert OnlyFromFactory();
+        _onRoll(loanID_, newDebt, newCollateral);
     }
 
     /// @notice Callback function that handles defaults.
-    function onDefault(uint256 loanID, uint256 debt, uint256 collateral) external {
-        _onDefault(loanID, debt, collateral);
+    function onDefault(uint256 loanID_, uint256 debt, uint256 collateral) external {
+        if(!factory.created(msg.sender)) revert OnlyFromFactory();
+        _onDefault(loanID_, debt, collateral);
     }
 
     // --- INTERNAL FUNCTIONS ------------------------------------------------
 
-    /// @dev Ensures that the callback caller is a Cooler deployed by the factory.
-    ///      Failing to implement this check properly may lead to unexpected/malicious
-    ///      contracts calling the lender's callback functions.
-    function _onlyFromFactory() internal view virtual {
-        if(!factory.created(msg.sender)) revert OnlyFromFactory();
-    }
-
-    /// @notice Callback function that handles repayments.
-    function _onRepay(uint256 loanID, uint256 amount) internal virtual { 
-        _onlyFromFactory();
-        // Callback Logic
-    }
+    /// @notice Callback function that handles repayments. Override for custom logic.
+    function _onRepay(uint256 loanID_, uint256 amount_) internal virtual;
 
     /// @notice Callback function that handles rollovers.
-    function _onRoll(uint256 loanID, uint256 newDebt, uint256 newCollateral) internal virtual {
-        _onlyFromFactory();
-        // Callback Logic
-    }
+    function _onRoll(uint256 loanID_, uint256 newDebt, uint256 newCollateral) internal virtual;
 
     /// @notice Callback function that handles defaults.
-    function _onDefault(uint256 loanID, uint256 debt, uint256 collateral) internal virtual {
-        _onlyFromFactory();
-        // Callback Logic
-    }
+    function _onDefault(uint256 loanID_, uint256 debt, uint256 collateral) internal virtual;
 }

--- a/src/CoolerCallback.sol
+++ b/src/CoolerCallback.sol
@@ -1,10 +1,36 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
+import {CoolerFactory} from "src/CoolerFactory.sol";
+
 /// @notice Allows for debt issuers to execute logic when a loan is repaid, rolled, or defaulted.
 abstract contract CoolerCallback {
-    function isCoolerCallback() external pure returns (bool) {return true; }
-    function onDefault(uint256 loanID, uint256 amount, uint256 collateral) external virtual;
-    function onRepay(uint256 loanID, uint256 amount) external virtual;
-    function onRoll(uint256 loanID) external virtual;
+
+    CoolerFactory public immutable factory;
+
+    constructor(address coolerFactory_) {
+        factory = CoolerFactory(coolerFactory_);
+    }
+
+    function isCoolerCallback() external pure returns (bool) {
+        return true;
+    }
+
+    function onDefault(uint256 loanID, uint256 amount, uint256 collateral) external virtual {        
+        // Validate caller is cooler.
+        require(factory.created(msg.sender), "ONLY_FROM_FACTORY");
+        // Callback Logic
+    }
+
+    function onRepay(uint256 loanID, uint256 amount) external virtual {        
+        // Validate caller is cooler.
+        require(factory.created(msg.sender), "ONLY_FROM_FACTORY");
+        // Callback Logic
+    }
+
+    function onRoll(uint256 loanID) external virtual {        
+        // Validate caller is cooler.
+        require(factory.created(msg.sender), "ONLY_FROM_FACTORY");
+        // Callback Logic
+    }
 }

--- a/src/CoolerCallback.sol
+++ b/src/CoolerCallback.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0;
 import {CoolerFactory} from "src/CoolerFactory.sol";
 
 /// @notice Allows for debt issuers to execute logic when a loan is repaid, rolled, or defaulted.
+/// @dev    The three callback functions must be implemented if `isCoolerCallback()` is set to true.
 abstract contract CoolerCallback {
 
     CoolerFactory public immutable factory;
@@ -12,25 +13,34 @@ abstract contract CoolerCallback {
         factory = CoolerFactory(coolerFactory_);
     }
 
+    /// @notice Informs to Cooler that this contract can handle its callbacks.
     function isCoolerCallback() external pure returns (bool) {
         return true;
     }
 
-    function onDefault(uint256 loanID, uint256 amount, uint256 collateral) external virtual {        
+    /// @dev Ensures that the callback caller is a Cooler deployed by the factory.
+    ///      Failing to implement this check properly may lead to unexpected/malicious
+    ///      contracts calling the lender's callback functions.
+    function _onlyFromFactory() internal view {
         // Validate caller is cooler.
         require(factory.created(msg.sender), "ONLY_FROM_FACTORY");
+    }
+
+    /// @notice Callback function that handles defaults.
+    function onDefault(uint256 loanID, uint256 amount, uint256 collateral) external virtual {
+        _onlyFromFactory();
         // Callback Logic
     }
 
-    function onRepay(uint256 loanID, uint256 amount) external virtual {        
-        // Validate caller is cooler.
-        require(factory.created(msg.sender), "ONLY_FROM_FACTORY");
+    /// @notice Callback function that handles repayments.
+    function onRepay(uint256 loanID, uint256 amount) external virtual { 
+        _onlyFromFactory();
         // Callback Logic
     }
 
-    function onRoll(uint256 loanID) external virtual {        
-        // Validate caller is cooler.
-        require(factory.created(msg.sender), "ONLY_FROM_FACTORY");
+    /// @notice Callback function that handles rollovers.
+    function onRoll(uint256 loanID) external virtual {
+        _onlyFromFactory();
         // Callback Logic
     }
 }

--- a/src/test/ClearingHouse.t.sol
+++ b/src/test/ClearingHouse.t.sol
@@ -78,15 +78,13 @@ contract ClearingHouseTest is Test {
     address internal user;
     address internal others;
     address internal overseer;
-    address internal streamer;
     uint256 internal initialSDai;
 
     function setUp() public {
-        address[] memory users = (new UserFactory()).create(4);
+        address[] memory users = (new UserFactory()).create(3);
         user = users[0];
         others = users[1];
         overseer = users[2];
-        streamer = users[3];
 
         MockStaking staking = new MockStaking();
         factory = new CoolerFactory();
@@ -107,8 +105,7 @@ contract ClearingHouseTest is Test {
             address(staking),
             address(sdai),
             address(factory),
-            address(kernel),
-            streamer
+            address(kernel)
         );
         rolesAdmin = new RolesAdmin(kernel);
 

--- a/src/test/ClearingHouse.t.sol
+++ b/src/test/ClearingHouse.t.sol
@@ -17,7 +17,7 @@ import {OlympusMinter, MINTRv1} from "olympus-v3/modules/MINTR/OlympusMinter.sol
 import {OlympusTreasury, TRSRYv1} from "olympus-v3/modules/TRSRY/OlympusTreasury.sol";
 //import {Actions} from "olympus-v3/Kernel.sol";
 
-import {ClearingHouse, Cooler, CoolerFactory} from "src/ClearingHouse.sol";
+import {ClearingHouse, Cooler, CoolerFactory, CoolerCallback} from "src/ClearingHouse.sol";
 //import {Cooler, Loan, Request} from "src/Cooler.sol";
 
 // Tests for ClearingHouse
@@ -224,7 +224,7 @@ contract ClearingHouseTest is Test {
         Cooler maliciousCooler = Cooler(maliciousFactory.generateCooler(gohm, dai));
         // Coolers not created by the CoolerFactory could be malicious.
         vm.prank(address(maliciousCooler));
-        vm.expectRevert(ClearingHouse.OnlyFromFactory.selector);
+        vm.expectRevert(CoolerCallback.OnlyFromFactory.selector);
         clearinghouse.lendToCooler(maliciousCooler, 1e18);
     }
 
@@ -455,7 +455,7 @@ contract ClearingHouseTest is Test {
         Cooler maliciousCooler = Cooler(maliciousFactory.generateCooler(gohm, dai));
         // Coolers not created by the CoolerFactory could be malicious.
         vm.prank(address(maliciousCooler));
-        vm.expectRevert(ClearingHouse.OnlyFromFactory.selector);
+        vm.expectRevert(CoolerCallback.OnlyFromFactory.selector);
         clearinghouse.onRepay(0, 1e18);
     }
 

--- a/src/test/ClearingHouse.t.sol
+++ b/src/test/ClearingHouse.t.sol
@@ -469,8 +469,9 @@ contract ClearingHouseTest is Test {
         // Move forward after the loan has ended
         _skip(clearinghouse.DURATION() + 1);
 
-        // Cache clearinghouse receivables
+        // Cache clearinghouse receivables and TRSRY debt
         uint256 initReceivables = clearinghouse.receivables();
+        uint256 initDebt = TRSRY.reserveDebt(sdai, address(clearinghouse));
         
         // Claim defaulted loan
         vm.prank(overseer);
@@ -478,6 +479,8 @@ contract ClearingHouseTest is Test {
 
         // Check: clearinghouse storage
         assertEq(clearinghouse.receivables(), initReceivables > initLoan.amount ? initReceivables - initLoan.amount : 0);
+        // Check: TRSRY storage
+        assertEq(TRSRY.reserveDebt(sdai, address(clearinghouse)), initDebt > initLoan.amount ? initDebt - initLoan.amount : 0);
     }
 
     function testRevert_onDefault_notFromFactory() public {

--- a/src/test/ClearingHouse.t.sol
+++ b/src/test/ClearingHouse.t.sol
@@ -78,13 +78,15 @@ contract ClearingHouseTest is Test {
     address internal user;
     address internal others;
     address internal overseer;
+    address internal streamer;
     uint256 internal initialSDai;
 
     function setUp() public {
-        address[] memory users = (new UserFactory()).create(3);
+        address[] memory users = (new UserFactory()).create(4);
         user = users[0];
         others = users[1];
         overseer = users[2];
+        streamer = users[3];
 
         MockStaking staking = new MockStaking();
         factory = new CoolerFactory();
@@ -105,7 +107,8 @@ contract ClearingHouseTest is Test {
             address(staking),
             address(sdai),
             address(factory),
-            address(kernel)
+            address(kernel),
+            streamer
         );
         rolesAdmin = new RolesAdmin(kernel);
 
@@ -254,7 +257,7 @@ contract ClearingHouseTest is Test {
         assertEq(dai.balanceOf(address(user)), loanAmount_);
         assertEq(dai.balanceOf(address(cooler)), 0);
         // Check: clearinghouse storage
-        assertEq(clearinghouse.receivables(), clearinghouse.loanForCollateral(gohmNeeded));
+        assertEq(clearinghouse.receivables(), clearinghouse.debtForCollateral(gohmNeeded));
         assertApproxEqAbs(clearinghouse.receivables(), cooler.getLoan(loanID).amount, 1e4);
     }
 
@@ -456,67 +459,61 @@ contract ClearingHouseTest is Test {
         clearinghouse.onRepay(0, 1e18);
     }
 
-    // --- CALLBACKS: ON LOAN DEFAULT ----------------------------------
+    // --- CLAIM DEFAULTED ----------------------------------
 
-    function test_onDefault(uint256 loanAmount_) public {
+    function testFuzz_claimDefaulted(uint256 loanAmount_) public {
         // Loan amount cannot exceed Clearinghouse funding
         // Loan amount must exceed 0.0001 gOHM, so that repaying the interest decollaterizes de loan.
-        loanAmount_ = bound(loanAmount_, 1e14, clearinghouse.FUND_AMOUNT());
+        uint256 loanAmount1_ = bound(loanAmount_, 1e14, clearinghouse.FUND_AMOUNT() / 3);
+        uint256 loanAmount2_ = 2 * loanAmount1_;
 
-        (Cooler cooler, uint256 gohmNeeded, uint256 loanID) = _createLoanForUser(loanAmount_);
-        Cooler.Loan memory initLoan = cooler.getLoan(loanID);
+        (Cooler cooler1, uint256 gohmNeeded1, uint256 loanID1) = _createLoanForUser(loanAmount1_);
+        (Cooler cooler2, uint256 gohmNeeded2, uint256 loanID2) = _createLoanForUser(loanAmount2_);
+        Cooler.Loan memory initLoan1 = cooler1.getLoan(loanID1);
+        Cooler.Loan memory initLoan2 = cooler2.getLoan(loanID2);
 
-        // Move forward after the loan has ended
+        // Move forward after both loans have ended
         _skip(clearinghouse.DURATION() + 1);
 
         // Cache clearinghouse receivables and TRSRY debt
         uint256 initReceivables = clearinghouse.receivables();
         uint256 initDebt = TRSRY.reserveDebt(sdai, address(clearinghouse));
-        
-        // Claim defaulted loan
-        vm.prank(overseer);
-        cooler.claimDefaulted(loanID);
 
+        // Simulate unstaking outcome after defaults
+        ohm.mint(address(clearinghouse), gohmNeeded1 + gohmNeeded2);
+
+        uint256[] memory ids = new uint256[](2);
+        address[] memory coolers = new address[](2);
+        ids[0] = loanID1;
+        ids[1] = loanID2;
+        coolers[0] = address(cooler1);
+        coolers[1] = address(cooler2);        
+        // Claim defaulted loans
+        vm.prank(overseer);
+        clearinghouse.claimDefaulted(coolers, ids);
+
+        uint256 daiReceivables = initLoan1.amount + initLoan2.amount;
+        uint256 sdaiDebt = sdai.previewDeposit(daiReceivables - clearinghouse.interestFromDebt(daiReceivables));
         // Check: clearinghouse storage
-        assertEq(clearinghouse.receivables(), initReceivables > initLoan.amount ? initReceivables - initLoan.amount : 0);
+        assertEq(clearinghouse.receivables(), initReceivables > daiReceivables ? initReceivables - daiReceivables : 0);
         // Check: TRSRY storage
-        assertEq(TRSRY.reserveDebt(sdai, address(clearinghouse)), initDebt > initLoan.amount ? initDebt - initLoan.amount : 0);
-    }
-
-    function testRevert_onDefault_notFromFactory() public {
-        CoolerFactory maliciousFactory = new CoolerFactory();
-        Cooler maliciousCooler = Cooler(maliciousFactory.generateCooler(gohm, dai));
-        // Coolers not created by the CoolerFactory could be malicious.
-        vm.prank(address(maliciousCooler));
-        vm.expectRevert(ClearingHouse.OnlyFromFactory.selector);
-        clearinghouse.onDefault(0, 0, 0);
-    }
-
-    // --- BURN (AFTER DEFAULT) ------------------------------------------
-
-    function test_burn(uint256 loanAmount_) public {
-        // Loan amount cannot exceed Clearinghouse funding
-        // Loan amount must exceed 0.0001 gOHM, so that repaying the interest decollaterizes de loan.
-        loanAmount_ = bound(loanAmount_, 1e14, clearinghouse.FUND_AMOUNT());
-
-        (Cooler cooler, uint256 gohmNeeded, uint256 loanID) = _createLoanForUser(loanAmount_);
-        Cooler.Loan memory initLoan = cooler.getLoan(loanID);
-
-        // Move forward after the loan has ended
-        _skip(clearinghouse.DURATION() + 1);
-
-        // Claim defaulted loan
-        vm.prank(overseer);
-        cooler.claimDefaulted(loanID);
-        
-        // After default the clearing house keeps the collateral 
-        assertEq(gohm.balanceOf(address(clearinghouse)), gohmNeeded);
-        // Simulate unstaking outcome
-        ohm.mint(address(clearinghouse), gohmNeeded);
-
-        clearinghouse.burn();
-
+        assertApproxEqAbs(TRSRY.reserveDebt(sdai, address(clearinghouse)), initDebt > sdaiDebt ? initDebt - sdaiDebt : 0, 1e4);
+        // After defaults the clearing house keeps the collateral (which is supposed to be unstaked and burned)
+        assertEq(gohm.balanceOf(address(clearinghouse)), gohmNeeded1 + gohmNeeded2, "gOHM balance");
         // Check: OHM supply = 0 (only minted before burning)
         assertEq(ohm.totalSupply(), 0);
+    }
+
+    function testRevert_claimDefaulted_inputLengthDiscrepancy() public {
+        uint256[] memory ids = new uint256[](2);
+        address[] memory coolers = new address[](1);
+        ids[0] = 12345;
+        ids[1] = 67890;
+        coolers[0] = others;  
+        // Claim defaulted loans
+        vm.prank(overseer);
+        // Both input arrays must have the same length
+        vm.expectRevert(ClearingHouse.LengthDiscrepancy.selector);
+        clearinghouse.claimDefaulted(coolers, ids);
     }
 }

--- a/src/test/mocks/MockMaliciousLender.sol
+++ b/src/test/mocks/MockMaliciousLender.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.0;
+
+import {CoolerCallback} from "src/CoolerCallback.sol";
+import {Cooler} from "src/Cooler.sol";
+
+contract MockMaliciousLender is CoolerCallback {
+    constructor(address coolerFactory_) CoolerCallback(coolerFactory_) {}
+    
+    /// @notice Callback function that handles repayments. Override for custom logic.
+    function _onRepay(uint256 loanID_, uint256 amount_) internal override {
+        Cooler(msg.sender).repayLoan(loanID_, amount_);
+    }
+
+    /// @notice Callback function that handles rollovers.
+    function _onRoll(uint256 loanID_, uint256 newDebt, uint256 newCollateral) internal override {
+        Cooler(msg.sender).rollLoan(loanID_);
+    }
+
+    /// @notice Callback function that handles defaults.
+    function _onDefault(uint256 loanID_, uint256 debt, uint256 collateral) internal override {
+        Cooler(msg.sender).claimDefaulted(loanID_);
+    }
+}


### PR DESCRIPTION
Add new tests to ensure that the `Cooler` contracts are safe from reentrancy attacks despite using callbacks.