### PR TITLE
feat: incentivize default claims with auction-style mechanism

### DIFF
--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -114,8 +114,9 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
         // Validate cooler collateral and debt tokens.
         if (cooler_.collateral() != gOHM || cooler_.debt() != dai) revert BadEscrow();
 
-        // Compute and access collateral.
+        // Compute and access collateral. Increment loan receivables.
         uint256 collateral = cooler_.collateralFor(amount_, LOAN_TO_COLLATERAL);
+        receivables += debtForCollateral(collateral);
         gOHM.transferFrom(msg.sender, address(this), collateral);
 
         // Create loan request.
@@ -126,9 +127,6 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
         sDai.withdraw(amount_, address(this), address(this));
         dai.approve(address(cooler_), amount_);
         uint256 loanID = cooler_.clearRequest(reqID, true, true);
-
-        // Increment loan receivables.
-        receivables += debtForCollateral(collateral);
         
         return loanID;
     }
@@ -146,6 +144,15 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
         // Provide rollover terms.
         cooler_.provideNewTermsForRoll(loanID_, INTEREST_RATE, LOAN_TO_COLLATERAL, DURATION);
 
+        // Increment loan receivables by applying the interest to the previous debt.
+        uint256 newDebt = cooler_.interestFor(
+            cooler_.getLoan(loanID_).amount,
+            INTEREST_RATE,              
+            DURATION
+        );
+        receivables += newDebt;
+    
+
         // Collect applicable new collateral from user.
         uint256 newCollateral = cooler_.newCollateralFor(loanID_);
         if (newCollateral > 0) {
@@ -155,9 +162,6 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
 
         // Roll loan.
         cooler_.rollLoan(loanID_);
-
-        // Increment loan receivables.
-        receivables += debtForCollateral(newCollateral);
     }
 
     /// @notice Batch several default claims to save gas.

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -136,6 +136,9 @@ contract Cooler is Clone {
     }
 
     /// @notice Repay a loan to get the collateral back.
+    /// @dev    Despite a malicious lender could reenter with the callback, the
+    ///         usage of `msg.sender` prevents any economical benefit to the
+    ///         attacker, since they would be repaying the loan themselves.
     /// @param  loanID_ index of loan in loans[]
     /// @param  repaid_ debt tokens to be repaid.
     /// @return collateral given back to the borrower.

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -286,8 +286,8 @@ contract Cooler is Clone {
 
     /// @notice Claim collateral upon loan default.
     /// @param loanID_ index of loan in loans[]
-    /// @return defaulted debt by the borrower and collateral kept by the lender.
-    function claimDefaulted(uint256 loanID_) external returns (uint256, uint256) {
+    /// @return defaulted debt by the borrower, collateral kept by the lender, elapsed time since expiry.
+    function claimDefaulted(uint256 loanID_) external returns (uint256, uint256, uint256) {
         Loan memory loan = loans[loanID_];
         delete loans[loanID_];
 
@@ -299,7 +299,7 @@ contract Cooler is Clone {
         factory().newEvent(loanID_, CoolerFactory.Events.DefaultLoan, 0);
 
         if (loan.callback) CoolerCallback(loan.lender).onDefault(loanID_, loan.amount, loan.collateral);
-        return (loan.amount, loan.collateral);
+        return (loan.amount, loan.collateral, block.timestamp - loan.expiry);
     }
 
     /// @notice Approve transfer of loan ownership rights to a new address.

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -270,6 +270,7 @@ contract ClearinghouseTest is Test {
 
         // Cache DAI balance and extra interest to be paid
         uint256 initDaiUser = dai.balanceOf(user);
+        uint256 initReceivables = clearinghouse.receivables();
         uint256 interestExtra = cooler.interestFor(initLoan.amount, clearinghouse.INTEREST_RATE(), clearinghouse.DURATION());
         // Ensure user has enough collateral to roll the loan
         uint256 gohmExtra = cooler.newCollateralFor(loanID);
@@ -288,6 +289,8 @@ contract ClearinghouseTest is Test {
         assertEq(newLoan.unclaimed, initLoan.unclaimed);
         assertEq(newLoan.collateral, initLoan.collateral + gohmExtra);
         assertEq(newLoan.expiry, initLoan.expiry + initLoan.request.duration);
+        // Check: clearinghouse storage
+        assertEq(clearinghouse.receivables(), initReceivables + interestExtra);
     }
 
     function testFuzz_rollLoan_repayingInterest(uint256 loanAmount_) public {
@@ -304,6 +307,7 @@ contract ClearinghouseTest is Test {
         vm.startPrank(user);
         // Cache DAI balance and extra interest to be paid in the future
         uint256 initDaiUser = dai.balanceOf(user);
+        uint256 initReceivables = clearinghouse.receivables();
         // Repay the interest of the loan (interest = owed debt - borrowed amount)
         uint256 repay = initLoan.amount - initLoan.request.amount;
         dai.approve(address(cooler), repay);
@@ -323,6 +327,8 @@ contract ClearinghouseTest is Test {
         assertEq(newLoan.unclaimed, initLoan.unclaimed);
         assertEq(newLoan.collateral, initLoan.collateral);
         assertEq(newLoan.expiry, initLoan.expiry + initLoan.request.duration);
+        // Check: clearinghouse storage
+        assertEq(clearinghouse.receivables(), initReceivables);
     }
 
     // --- REBALANCE TREASURY --------------------------------------------

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -26,6 +26,7 @@ import {Clearinghouse, Cooler, CoolerFactory, CoolerCallback} from "src/Clearing
 //
 // Clearinghouse Functions
 // [X] rebalance
+//     [X] can't if the contract is deactivated.
 //     [X] can't rebalance faster than the funding cadence.
 //     [X] Treasury approvals for the clearing house are correct.
 //     [X] if necessary, sends excess DSR funds back to the Treasury.
@@ -36,6 +37,12 @@ import {Clearinghouse, Cooler, CoolerFactory, CoolerCallback} from "src/Clearing
 //     [X] only "cooler_overseer" can call.
 //     [X] cannot defund gOHM.
 //     [X] sends input ERC20 token back to the Treasury.
+// [X] emergencyShutdown
+//     [X] only "emergency_shutdown" can call.
+//     [X] deactivates and defunds.
+// [X] restartAfterShutdown
+//     [X] only "cooler_overseer" can call.
+//     [X] reactivates.
 // [X] lendToCooler
 //     [X] only lend to coolers issued by coolerFactory.
 //     [X] only collateral = gOHM + only debt = DAI.
@@ -116,6 +123,7 @@ contract ClearinghouseTest is Test {
 
         /// Configure access control
         rolesAdmin.grantRole("cooler_overseer", overseer);
+        rolesAdmin.grantRole("emergency_shutdown", overseer);
 
         // Setup clearinghouse initial conditions
         uint mintAmount = 200_000_000e18; // Init treasury with 200 million
@@ -444,6 +452,20 @@ contract ClearinghouseTest is Test {
         );
     }
 
+    function test_rebalance_deactivated_returnFunds() public {
+        vm.prank(overseer);
+        clearinghouse.emergencyShutdown();
+
+        // Simulate loan repayments
+        uint256 oneMillion = 1e24;
+        deal(address(sdai), address(clearinghouse), oneMillion);
+        uint256 sdaiInitTRSRY = sdai.balanceOf(address(TRSRY));
+        // Rebalances only defund when the contract is deactivated.
+        clearinghouse.rebalance();
+        assertEq(sdai.balanceOf(address(clearinghouse)), 0);
+        assertEq(sdai.balanceOf(address(TRSRY)), sdaiInitTRSRY + oneMillion);
+    }
+
     function testRevert_rebalance_early() public {
         bool canRebalance;
         // Rebalance to be up-to-date with the FUND_CADENCE.
@@ -479,15 +501,57 @@ contract ClearinghouseTest is Test {
 
     function test_defund() public {
         uint256 sdaiTrsryBal = sdai.balanceOf(address(TRSRY));
+        uint256 initDebtCH = TRSRY.reserveDebt(dai, address(clearinghouse));
+
         vm.prank(overseer);
         clearinghouse.defund(sdai, 1e24);
         assertEq(sdai.balanceOf(address(TRSRY)), sdaiTrsryBal + 1e24);
+        assertEq(TRSRY.reserveDebt(dai, address(clearinghouse)), initDebtCH - sdai.previewRedeem(1e24));
     }
 
     function testRevert_defund_gohm() public {
         vm.prank(overseer);
         vm.expectRevert(Clearinghouse.OnlyBurnable.selector);
         clearinghouse.defund(gohm, 1e24);
+    }
+
+    function testRevert_defund_onlyRole() public {
+        vm.prank(others);
+        vm.expectRevert();
+        clearinghouse.defund(gohm, 1e24);
+    }
+
+    // --- EMERGENCY SHUTDOWN CLEARINGHOUSE ------------------------------
+
+    function test_emergencyShutdown() public {
+        uint256 sdaiTrsryBal = sdai.balanceOf(address(TRSRY));
+        uint256 sdaiCHBal = sdai.balanceOf(address(clearinghouse));
+
+        vm.prank(overseer);
+        clearinghouse.emergencyShutdown();
+        assertEq(clearinghouse.active(), false);
+        assertEq(sdai.balanceOf(address(TRSRY)), sdaiTrsryBal + sdaiCHBal);
+    }
+
+    function testRevert_emergencyShutdown_onlyRole() public {
+        vm.prank(others);
+        vm.expectRevert();
+        clearinghouse.emergencyShutdown();
+    }
+
+    function test_reactivate() public {
+        vm.startPrank(overseer);
+        clearinghouse.emergencyShutdown();
+        assertEq(clearinghouse.active(), false);
+        clearinghouse.reactivate();
+        assertEq(clearinghouse.active(), true);
+        vm.stopPrank();
+    }
+
+    function testRevert_restartAfterShutdown_onlyRole() public {
+        vm.prank(others);
+        vm.expectRevert();
+        clearinghouse.reactivate();
     }
 
     // --- CALLBACKS: ON LOAN REPAYMENT ----------------------------------


### PR DESCRIPTION
- auction-style reward system that linearly increases up to a max reward.
- keeper reward capped at 5% of the collateral amount to ensure no dilution for OHM holders
- keeper reward capped at `MAX_REWARD` = 0.1 gOHM per loan.
- since writing the loans off the books is not time-sensitive, there is a 7-day window until max reward is reached.