### PR TITLE
Fix Issue 254

### DIFF
--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -253,13 +253,7 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
         if (active) {
             _sweepIntoDSR(amount_);
         } else {
-            uint256 outstandingDebt = TRSRY.reserveDebt(dai, address(this));
-            TRSRY.setDebt({
-                debtor_: address(this),
-                token_: dai,
-                amount_: (outstandingDebt > amount_) ? outstandingDebt - amount_ : 0
-            });
-            dai.transfer(address(TRSRY), amount_);
+            _defund(dai, amount_);
         }
 
         // Decrement loan receivables.

--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -346,8 +346,15 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
     /// @notice Return funds to treasury.
     /// @param  token_ to transfer.
     /// @param  amount_ to transfer.
-    function defund(ERC20 token_, uint256 amount_) public onlyRole("cooler_overseer") {
+    function defund(ERC20 token_, uint256 amount_) external onlyRole("cooler_overseer") {
         if (token_ == gOHM) revert OnlyBurnable();
+        _defund(token_, amount_);
+    }
+
+    /// @notice Internal function to return funds to treasury.
+    /// @param  token_ to transfer.
+    /// @param  amount_ to transfer.
+    function _defund(ERC20 token_, uint256 amount_) internal {
         if (token_ == sdai || token_ == dai) {
             // Since users loans are denominated in DAI, the clearinghouse
             // debt is set in DAI terms. It must be adjusted when defunding.
@@ -372,11 +379,11 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
 
         // If necessary, defund sDAI.
         uint256 sdaiBalance = sdai.balanceOf(address(this));
-        if (sdaiBalance != 0) defund(sdai, sdaiBalance);
+        if (sdaiBalance != 0) _defund(sdai, sdaiBalance);
 
         // If necessary, defund DAI.
         uint256 daiBalance = dai.balanceOf(address(this));
-        if (daiBalance != 0) defund(dai, daiBalance);
+        if (daiBalance != 0) _defund(dai, daiBalance);
 
         emit Deactivated();
     }


### PR DESCRIPTION
#254: Withdraw tokens to treasury in _onRepay in ClearingHouse if emergency shutdown
Link to issue: https://github.com/sherlock-audit/2023-08-cooler-judging/issues/254
Fix description: If emergency shutdown (where boolean 'active' is false), forward DAI directly to treasury and adjust treasury debt counter.