### PR TITLE
Fix Issue 119

### DIFF
--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -317,9 +317,11 @@ contract Cooler is Clone {
     /// @return defaulted debt by the borrower, collateral kept by the lender, elapsed time since expiry.
     function claimDefaulted(uint256 loanID_) external returns (uint256, uint256, uint256) {
         Loan memory loan = loans[loanID_];
-        delete loans[loanID_];
 
         if (block.timestamp <= loan.expiry) revert NoDefault();
+
+        loans[loanID_].amount = 0;
+        loans[loanID_].collateral = 0;
 
         // Transfer defaulted collateral to the lender.
         collateral().safeTransfer(loan.lender, loan.collateral);

--- a/src/test/Cooler.t.sol
+++ b/src/test/Cooler.t.sol
@@ -653,12 +653,14 @@ contract CoolerTest is Test {
         ) = cooler.loans(loanID);
         
         // check: loan storage
+        // - only amount and collateral are cleared
         assertEq(0, loanAmount);
-        assertEq(0, loanUnclaimed);
         assertEq(0, loanCollat);
-        assertEq(0, loanExpiry);
-        assertEq(address(0), loanLender);
-        assertEq(false, loanDirect);
+        // - the rest of the variables are untouched
+        assertEq(0, loanUnclaimed);
+        assertEq(block.timestamp - 1, loanExpiry);
+        assertEq(lender, loanLender);
+        assertEq(true, loanDirect);
         assertEq(false, loanCallback);
     }
 
@@ -707,9 +709,9 @@ contract CoolerTest is Test {
         assertEq(0, loanAmount1, "loanAmount1");
         assertEq(0, loanUnclaimed1, "loanUnclaimed1");
         assertEq(0, loanCollat1, "loanCollat1");
-        assertEq(0, loanExpiry1, "loanExpiry1");
-        assertEq(address(0), loanLender1, "loanLender1");
-        assertEq(false, loanDirect1, "loanDirect1");
+        assertEq(block.timestamp - 1, loanExpiry1, "loanExpiry1");
+        assertEq(lender, loanLender1, "loanLender1");
+        assertEq(true, loanDirect1, "loanDirect1");
         assertEq(false, loanCallback1, "loanCallback1");
         }
         {


### PR DESCRIPTION
Summary: At claimDefaulted, the lender may not receive the token because the Unclaimed token is not processed
Issue Link: https://github.com/sherlock-audit/2023-08-cooler-judging/issues/119
Fix Description: Set amount and collateral to zero but do not delete loan struct.