### PR TITLE
Fix Issue 28

### DIFF
--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -31,6 +31,7 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
     error OnlyBurnable();
     error TooEarlyToFund();
     error LengthDiscrepancy();
+    error OnlyFromClearinghouse();
 
     // --- EVENTS ----------------------------------------------------
 
@@ -201,7 +202,7 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
             if (!factory.created(coolers_[i])) revert OnlyFromFactory();
 
             // Validate that loan was written by clearinghouse.
-            if (Cooler(coolers_[i]).getLoan(loans_[i]).lender != address(this)) continue;
+            if (Cooler(coolers_[i]).getLoan(loans_[i]).lender != address(this)) revert OnlyFromClearinghouse();
             
             // Claim defaults and update cached metrics.
             (uint256 debt, uint256 collateral, uint256 elapsed) = Cooler(coolers_[i]).claimDefaulted(loans_[i]);

--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -199,6 +199,9 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
         for (uint256 i=0; i < loans;) {
             // Validate that cooler was deployed by the trusted factory.
             if (!factory.created(coolers_[i])) revert OnlyFromFactory();
+
+            // Validate that loan was written by clearinghouse.
+            if (Cooler(coolers_[i]).getLoan(loanID_).lender != address(this)) continue;
             
             // Claim defaults and update cached metrics.
             (uint256 debt, uint256 collateral, uint256 elapsed) = Cooler(coolers_[i]).claimDefaulted(loans_[i]);

--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -201,7 +201,7 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
             if (!factory.created(coolers_[i])) revert OnlyFromFactory();
 
             // Validate that loan was written by clearinghouse.
-            if (Cooler(coolers_[i]).getLoan(loanID_).lender != address(this)) continue;
+            if (Cooler(coolers_[i]).getLoan(loans_[i]).lender != address(this)) continue;
             
             // Claim defaults and update cached metrics.
             (uint256 debt, uint256 collateral, uint256 elapsed) = Cooler(coolers_[i]).claimDefaulted(loans_[i]);

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -705,4 +705,39 @@ contract ClearinghouseTest is Test {
         vm.expectRevert(CoolerCallback.OnlyFromFactory.selector);
         clearinghouse.claimDefaulted(coolers, ids);
     }
+
+    function testRevert_claimDefaulted_NotFromClearinghouse() public {
+        // Create legit loan from Clearinghouse
+        (Cooler cooler, , uint256 loanID) = _createLoanForUser(100 * 1e18);
+
+        // Move forward after the loans have ended
+        _skip(clearinghouse.DURATION() + 1);
+        
+        // Attacker creates a fake loan for himself that defaults immediately
+        // to try to steal the defaulted collateral from legit loans.
+        vm.startPrank(others);
+        Cooler maliciousCooler = Cooler(factory.generateCooler(gohm, dai));
+
+        uint256 amountNeeded = maliciousCooler.collateralFor(1e14, 1);
+        gohm.mint(others, amountNeeded);
+        gohm.approve(address(maliciousCooler), amountNeeded);
+        dai.mint(others, amountNeeded);
+        dai.approve(address(maliciousCooler), amountNeeded);
+
+        uint256 reqID = maliciousCooler.requestLoan(1e14, 0, 1, 0);
+        uint256 maliciousLoanID = maliciousCooler.clearRequest(reqID, true, false);
+        vm.stopPrank();
+
+        uint256[] memory ids = new uint256[](2);
+        address[] memory coolers = new address[](2);
+        ids[0] = loanID;
+        coolers[0] = address(cooler);
+        ids[1] = maliciousLoanID;
+        coolers[1] = address(maliciousCooler);
+
+        // Loans not created by the Clearinghouse could be malicious.
+        vm.prank(others);
+        vm.expectRevert(Clearinghouse.OnlyFromClearinghouse.selector);
+        clearinghouse.claimDefaulted(coolers, ids);
+    }
 }


### PR DESCRIPTION
Summary: Can steal gOhm by calling Clearinghouse.claimDefaulted on loans not made by Clearinghouse
Issue Link: https://github.com/sherlock-audit/2023-08-cooler-judging/issues/28
Fix Description: Validate that a defaulted loan was written by the clearinghouse before incentivizing it.