### PR TITLE
Fix Issue 01

### DIFF
--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -337,14 +337,14 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
     /// @param  token_ to transfer.
     /// @param  amount_ to transfer.
     function defund(ERC20 token_, uint256 amount_) external onlyRole("cooler_overseer") {
+        if (token_ == gOHM) revert OnlyBurnable();
         _defund(token_, amount_);
     }
 
-    /// @notice Return funds to treasury.
+    /// @notice Internal function to return funds to treasury.
     /// @param  token_ to transfer.
     /// @param  amount_ to transfer.
     function _defund(ERC20 token_, uint256 amount_) internal {
-        if (token_ == gOHM) revert OnlyBurnable();
         if (token_ == sdai || token_ == dai) {
             // Since users loans are denominated in DAI, the clearinghouse
             // debt is set in DAI terms. It must be adjusted when defunding.

--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -336,7 +336,14 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
     /// @notice Return funds to treasury.
     /// @param  token_ to transfer.
     /// @param  amount_ to transfer.
-    function defund(ERC20 token_, uint256 amount_) public onlyRole("cooler_overseer") {
+    function defund(ERC20 token_, uint256 amount_) external onlyRole("cooler_overseer") {
+        _defund(token_, amount_);
+    }
+
+    /// @notice Return funds to treasury.
+    /// @param  token_ to transfer.
+    /// @param  amount_ to transfer.
+    function _defund(ERC20 token_, uint256 amount_) internal {
         if (token_ == gOHM) revert OnlyBurnable();
         if (token_ == sdai || token_ == dai) {
             // Since users loans are denominated in DAI, the clearinghouse
@@ -362,11 +369,11 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
 
         // If necessary, defund sDAI.
         uint256 sdaiBalance = sdai.balanceOf(address(this));
-        if (sdaiBalance != 0) defund(sdai, sdaiBalance);
+        if (sdaiBalance != 0) _defund(sdai, sdaiBalance);
 
         // If necessary, defund DAI.
         uint256 daiBalance = dai.balanceOf(address(this));
-        if (daiBalance != 0) defund(dai, daiBalance);
+        if (daiBalance != 0) _defund(dai, daiBalance);
 
         emit Deactivated();
     }

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -122,7 +122,7 @@ contract ClearinghouseTest is Test {
         kernel.executeAction(Actions.ActivatePolicy, address(rolesAdmin));
 
         /// Configure access control
-        rolesAdmin.grantRole("cooler_overseer", overseer);
+        //  rolesAdmin.grantRole("cooler_overseer", overseer);
         rolesAdmin.grantRole("emergency_shutdown", overseer);
 
         // Setup clearinghouse initial conditions

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -122,7 +122,7 @@ contract ClearinghouseTest is Test {
         kernel.executeAction(Actions.ActivatePolicy, address(rolesAdmin));
 
         /// Configure access control
-        //  rolesAdmin.grantRole("cooler_overseer", overseer);
+        rolesAdmin.grantRole("cooler_overseer", overseer);
         rolesAdmin.grantRole("emergency_shutdown", overseer);
 
         // Setup clearinghouse initial conditions


### PR DESCRIPTION
Summary: emergency_shutdown role is not enough for emergency shutdown.
Issue Link: https://github.com/sherlock-audit/2023-08-cooler-judging/issues/1
Fix Description: Refactor defund() into a permissioned external function and an unpermissioned _defund() internal function. emergencyShutdown() interacts with internal function instead of external function to avoid permissioning issue.