### PR TITLE
Fix Issue 30, 95, 187

### DIFF
--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -239,6 +239,9 @@ contract Cooler is Clone {
     ) external returns (uint256 loanID) {
         Request memory req = requests[reqID_];
 
+        // Loan callbacks are only allowed if:
+        //  1. The loan request has been created via a trusted lender.
+        //  2. The lender signals that it implements the CoolerCallback Abstract.
         bool callback = (isCallback_ && msg.sender == req.requester);
 
         // If necessary, ensure lender implements the CoolerCallback abstract.
@@ -299,7 +302,8 @@ contract Cooler is Clone {
                 interest_,
                 loanToCollateral_,
                 duration_,
-                true
+                true,
+                msg.sender
             );
     }
 

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -246,7 +246,6 @@ contract Cooler is Clone {
 
         // If necessary, ensure lender implements the CoolerCallback abstract.
         if (callback && !CoolerCallback(msg.sender).isCoolerCallback()) revert NotCoolerCallback();
-
         // Ensure loan request is active. 
         if (!req.active) revert Deactivated();
 

--- a/src/test/mocks/MockCallbackLender.sol
+++ b/src/test/mocks/MockCallbackLender.sol
@@ -4,21 +4,21 @@ pragma solidity ^0.8.0;
 import {CoolerCallback} from "src/CoolerCallback.sol";
 import {Cooler} from "src/Cooler.sol";
 
-contract MockMaliciousLender is CoolerCallback {
+contract MockLender is CoolerCallback {
     constructor(address coolerFactory_) CoolerCallback(coolerFactory_) {}
     
     /// @notice Callback function that handles repayments. Override for custom logic.
     function _onRepay(uint256 loanID_, uint256 amount_) internal override {
-        Cooler(msg.sender).repayLoan(loanID_, amount_);
+        // callback logic
     }
 
     /// @notice Callback function that handles rollovers.
     function _onRoll(uint256 loanID_, uint256 newDebt, uint256 newCollateral) internal override {
-        Cooler(msg.sender).rollLoan(loanID_);
+        // callback logic
     }
 
     /// @notice Callback function that handles defaults.
     function _onDefault(uint256 loanID_, uint256 debt, uint256 collateral) internal override {
-        Cooler(msg.sender).claimDefaulted(loanID_);
+        // callback logic
     }
 }


### PR DESCRIPTION
Summary: Malicious lender can use Callbacks to create Loan that cannot be repaid; Insufficient checks on transferOwnership can make important operations revert.; isCoolerCallback can be bypassed
Issue Links: https://github.com/sherlock-audit/2023-08-cooler-judging/issues/30 ; https://github.com/sherlock-audit/2023-08-cooler-judging/issues/95 ; https://github.com/sherlock-audit/2023-08-cooler-judging/issues/187
Fix Description: Only allow callbacks if the creator of the request is the same address as the lender (caller of 'clearRequest()'). This ensures that only a contract or known party is lending with a callback (note that lender could play both roles but they must put up the collateral so the risk is null). Under this structure, borrower should have visibility into callback logic. This does break if lending contract is upgradeable but I don't know how much more we can do.