### PR TITLE
chore: async extensions

### DIFF
--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -165,20 +165,16 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
 
         Cooler.Loan memory loan = cooler_.getLoan(loanID_);
 
-        // Ensure we are the lender
+        // Ensure Clearinghouse is the lender.
         if (loan.lender != address(this)) revert OnlyLender();
 
-        // Force interest repayment if necessary.
+        uint256 interestNew = interestForLoan(loan.principle, loan.request.duration);
         if (loan.interestDue == 0) {
             // If interest has manually been repaid, only update receivables.
-            uint256 interestNew = interestForLoan(loan.principle, loan.request.duration);
             interestReceivables += interestNew;
         } else {
             // Otherwise, transfer in interest due from the caller.
-            uint256 durationPassed = block.timestamp - loan.start;
-            uint256 interestDue = interestForLoan(loan.principle, durationPassed);
-            
-            dai.transferFrom(msg.sender, loan.recipient, interestDue);
+            dai.transferFrom(msg.sender, loan.recipient, interestNew);
         }
 
         // Signal to cooler that loan can be extended.

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -193,14 +193,14 @@ contract Cooler is Clone {
     }
 
     // Allow lender to extend loan for borrower. Any payments are done by the caller.
-    function extendLoanTerms(uint256 loanID_) external {
+    function extendLoanTerms(uint256 loanID_, uint8 times_) external {
         Loan memory loan = loans[loanID_];
 
         if (msg.sender != loan.lender) revert OnlyApproved();
         if (block.timestamp > loan.expiry) revert Default();
 
         // Update loan terms to reflect the extension.
-        loan.expiry += loan.request.duration;
+        loan.expiry += loan.request.duration * times_;
         loan.interestDue = interestFor(
             loan.request.amount,
             loan.request.interest,

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -42,7 +42,6 @@ contract Cooler is Clone {
         uint256 principle;      // Amount of principle debt owed to the lender.
         uint256 interestDue;    // Interest owed to the lender.
         uint256 collateral;     // Amount of collateral pledged.
-        uint256 start;          // Time when the loan was granted.
         uint256 expiry;         // Time when the loan defaults.
         address lender;         // Lender's address.
         address recipient;      // Recipient of repayments.
@@ -200,8 +199,8 @@ contract Cooler is Clone {
         if (msg.sender != loan.lender) revert OnlyApproved();
         if (block.timestamp > loan.expiry) revert Default();
 
-        // Update loan terms with original interest and expiry.
-        loan.expiry = block.timestamp + loan.request.duration;
+        // Update loan terms to reflect the extension.
+        loan.expiry += loan.request.duration;
         loan.interestDue = interestFor(
             loan.request.amount,
             loan.request.interest,
@@ -256,7 +255,6 @@ contract Cooler is Clone {
                 principle: req.amount,
                 interestDue: interest,
                 collateral: collat,
-                start: block.timestamp,
                 expiry: block.timestamp + req.duration,
                 lender: msg.sender,
                 recipient: recipient_,

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -310,22 +310,22 @@ contract ClearinghouseTest is Test {
         uint256 initDaiCH = dai.balanceOf(address(clearinghouse));
         uint256 initReceivables = clearinghouse.interestReceivables();
         // Repay the interest of the loan (interest = owed debt - borrowed amount)
-        uint256 interestOwed = clearinghouse.interestForLoan(initLoan.principle, elapsed_);
+        uint256 interestOwed = clearinghouse.interestForLoan(initLoan.principle, initLoan.request.duration);
         dai.approve(address(clearinghouse), interestOwed);
         // Extend loan
         clearinghouse.extendLoan(cooler, loanID);
         vm.stopPrank();
 
-        Cooler.Loan memory newLoan = cooler.getLoan(loanID);
+        Cooler.Loan memory extendedLoan = cooler.getLoan(loanID);
 
         // Check: balances
         assertEq(dai.balanceOf(user), initDaiUser - interestOwed, "DAI user");
         assertEq(dai.balanceOf(address(clearinghouse)), initDaiCH + interestOwed, "DAI CH");
         // Check: cooler storage
-        assertEq(newLoan.principle, initLoan.principle);
-        assertEq(newLoan.interestDue, initLoan.interestDue);
-        assertEq(newLoan.collateral, initLoan.collateral);
-        assertEq(newLoan.expiry, initLoan.expiry + elapsed_);
+        assertEq(extendedLoan.principle, initLoan.principle, "principle");
+        assertEq(extendedLoan.interestDue, initLoan.interestDue, "interest");
+        assertEq(extendedLoan.collateral, initLoan.collateral, "collateral");
+        assertEq(extendedLoan.expiry, initLoan.expiry + initLoan.request.duration, "expiry");
         // Check: clearinghouse storage
         assertEq(clearinghouse.interestReceivables(), initReceivables);
     }
@@ -354,18 +354,18 @@ contract ClearinghouseTest is Test {
         clearinghouse.extendLoan(cooler, loanID);
         vm.stopPrank();
 
-        Cooler.Loan memory newLoan = cooler.getLoan(loanID);
+        Cooler.Loan memory extendedLoan = cooler.getLoan(loanID);
 
         // Check: balances
         assertEq(dai.balanceOf(user), initDaiUser, "DAI user");
         assertEq(dai.balanceOf(address(clearinghouse)), initDaiCH, "DAI CH");
         // Check: cooler storage
-        assertEq(newLoan.principle, initLoan.principle);
-        assertEq(newLoan.interestDue, initLoan.interestDue);
-        assertEq(newLoan.collateral, initLoan.collateral);
-        assertEq(newLoan.expiry, initLoan.expiry + elapsed_);
+        assertEq(extendedLoan.principle, initLoan.principle, "principle");
+        assertEq(extendedLoan.interestDue, initLoan.interestDue, "interest");
+        assertEq(extendedLoan.collateral, initLoan.collateral, "collateral");
+        assertEq(extendedLoan.expiry, initLoan.expiry + initLoan.request.duration, "expiry");
         // Check: clearinghouse storage
-        assertEq(clearinghouse.interestReceivables(), initReceivables + newLoan.interestDue);
+        assertEq(clearinghouse.interestReceivables(), initReceivables + extendedLoan.interestDue);
     }
 
     function testRevert_extendLoan_OnlyLender() public {

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -293,10 +293,11 @@ contract ClearinghouseTest is Test {
 
     // --- EXTEND LOAN -----------------------------------------------------
 
-    function testFuzz_extendLoan(uint256 loanAmount_, uint256 elapsed_) public {
+    function testFuzz_extendLoan(uint256 loanAmount_, uint256 elapsed_, uint8 times_) public {
         // Loan amount cannot exceed Clearinghouse funding
         loanAmount_ = bound(loanAmount_, 0, clearinghouse.FUND_AMOUNT());
         elapsed_ = bound(elapsed_, 0, clearinghouse.DURATION());
+        times_ = uint8(bound(times_, 1, 255));
 
         (Cooler cooler, uint256 gohmNeeded, uint256 loanID) = _createLoanForUser(loanAmount_);
         Cooler.Loan memory initLoan = cooler.getLoan(loanID);
@@ -309,11 +310,11 @@ contract ClearinghouseTest is Test {
         uint256 initDaiUser = dai.balanceOf(user);
         uint256 initDaiCH = dai.balanceOf(address(clearinghouse));
         uint256 initReceivables = clearinghouse.interestReceivables();
-        // Repay the interest of the loan (interest = owed debt - borrowed amount)
-        uint256 interestOwed = clearinghouse.interestForLoan(initLoan.principle, initLoan.request.duration);
+        // Approve the interest of the extensions
+        uint256 interestOwed = clearinghouse.interestForLoan(initLoan.principle, initLoan.request.duration) * times_;
         dai.approve(address(clearinghouse), interestOwed);
         // Extend loan
-        clearinghouse.extendLoan(cooler, loanID);
+        clearinghouse.extendLoan(cooler, loanID, times_);
         vm.stopPrank();
 
         Cooler.Loan memory extendedLoan = cooler.getLoan(loanID);
@@ -325,14 +326,16 @@ contract ClearinghouseTest is Test {
         assertEq(extendedLoan.principle, initLoan.principle, "principle");
         assertEq(extendedLoan.interestDue, initLoan.interestDue, "interest");
         assertEq(extendedLoan.collateral, initLoan.collateral, "collateral");
-        assertEq(extendedLoan.expiry, initLoan.expiry + initLoan.request.duration, "expiry");
+        assertEq(extendedLoan.expiry, initLoan.expiry + initLoan.request.duration * times_, "expiry");
         // Check: clearinghouse storage
         assertEq(clearinghouse.interestReceivables(), initReceivables);
     }
-    function testFuzz_extendLoan_withPriorRepayment(uint256 loanAmount_, uint256 elapsed_) public {
+
+    function testFuzz_extendLoan_withPriorRepayment(uint256 loanAmount_, uint256 elapsed_, uint8 times_) public {
         // Loan amount cannot exceed Clearinghouse funding
         loanAmount_ = bound(loanAmount_, 1e10, clearinghouse.FUND_AMOUNT());
         elapsed_ = bound(elapsed_, 0, clearinghouse.DURATION());
+        times_ = uint8(bound(times_, 1, 255));
 
         (Cooler cooler, uint256 gohmNeeded, uint256 loanID) = _createLoanForUser(loanAmount_);
         Cooler.Loan memory initLoan = cooler.getLoan(loanID);
@@ -342,33 +345,36 @@ contract ClearinghouseTest is Test {
 
         vm.startPrank(user);
         dai.approve(address(cooler), initLoan.interestDue);
-        // Repay interest manually
+        // Repay interest of the first extension manually
         cooler.repayLoan(loanID, initLoan.interestDue);
 
         // Cache DAI balance and interest after repayment
         uint256 initDaiUser = dai.balanceOf(user);
         uint256 initDaiCH = dai.balanceOf(address(clearinghouse));
         uint256 initReceivables = clearinghouse.interestReceivables();
+        // Approve the interest of the followup extensions
+        uint256 interestOwed = clearinghouse.interestForLoan(initLoan.principle, initLoan.request.duration) * (times_ - 1);
+        dai.approve(address(clearinghouse), interestOwed);
 
         // Extend loan
-        clearinghouse.extendLoan(cooler, loanID);
+        clearinghouse.extendLoan(cooler, loanID, times_);
         vm.stopPrank();
 
         Cooler.Loan memory extendedLoan = cooler.getLoan(loanID);
 
         // Check: balances
-        assertEq(dai.balanceOf(user), initDaiUser, "DAI user");
-        assertEq(dai.balanceOf(address(clearinghouse)), initDaiCH, "DAI CH");
+        assertEq(dai.balanceOf(user), initDaiUser - interestOwed, "DAI user");
+        assertEq(dai.balanceOf(address(clearinghouse)), initDaiCH + interestOwed, "DAI CH");
         // Check: cooler storage
         assertEq(extendedLoan.principle, initLoan.principle, "principle");
         assertEq(extendedLoan.interestDue, initLoan.interestDue, "interest");
         assertEq(extendedLoan.collateral, initLoan.collateral, "collateral");
-        assertEq(extendedLoan.expiry, initLoan.expiry + initLoan.request.duration, "expiry");
+        assertEq(extendedLoan.expiry, initLoan.expiry + initLoan.request.duration * times_, "expiry");
         // Check: clearinghouse storage
         assertEq(clearinghouse.interestReceivables(), initReceivables + extendedLoan.interestDue);
     }
 
-    function testRevert_extendLoan_OnlyLender() public {
+    function testRevert_extendLoan_NotLender() public {
         CoolerFactory maliciousFactory = new CoolerFactory();
         Cooler maliciousCooler = Cooler(maliciousFactory.generateCooler(gohm, dai));
 
@@ -377,8 +383,8 @@ contract ClearinghouseTest is Test {
         uint256 loanID = maliciousCooler.clearRequest(reqID, others, false);
 
         // Only extendable for loans where the CH is the lender.
-        vm.expectRevert(Clearinghouse.OnlyLender.selector);
-        clearinghouse.extendLoan(maliciousCooler, loanID);
+        vm.expectRevert(Clearinghouse.NotLender.selector);
+        clearinghouse.extendLoan(maliciousCooler, loanID, 1);
     }
 
     // --- REBALANCE TREASURY --------------------------------------------


### PR DESCRIPTION
Updates the extension logic to:
- allow async extensions > users can pay the interest beforehand and come back after `N * 4 months`.
- if a user has manually paid the interest, the extension is "free".