### PR TITLE
chore: improve event logging

### DIFF
--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -375,7 +375,7 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
 
         // Defund and log the event
         token_.transfer(address(TRSRY), amount_);
-        emit Defund(address(token), - int256(amount_));
+        emit Defund(address(token_), - int256(amount_));
     }
 
     /// @notice Deactivate the contract and return funds to treasury.

--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -36,8 +36,10 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
 
     // --- EVENTS ----------------------------------------------------
 
-    event Deactivated();
-    event Reactivated();
+    event Defund();
+    event Rebalance();
+    event Deactivate();
+    event Reactivate();
     
     // --- RELEVANT CONTRACTS ----------------------------------------
 
@@ -328,6 +330,9 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
             sdai.approve(address(TRSRY), sdaiAmount);
             sdai.transfer(address(TRSRY), sdaiAmount);
         }
+
+        // Log the event.
+        emit Rebalance();
         return true;
     }
 
@@ -363,7 +368,9 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
             });
         }
 
+        // Defund and log the event
         token_.transfer(address(TRSRY), amount_);
+        emit Defund();
     }
 
     /// @notice Deactivate the contract and return funds to treasury.
@@ -378,14 +385,14 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
         uint256 daiBalance = dai.balanceOf(address(this));
         if (daiBalance != 0) defund(dai, daiBalance);
 
-        emit Deactivated();
+        emit Deactivate();
     }
 
     /// @notice Reactivate the contract.
     function reactivate() external onlyRole("cooler_overseer") {
         active = true;
 
-        emit Reactivated();
+        emit Reactivate();
     }
 
     // --- AUX FUNCTIONS ---------------------------------------------

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -119,7 +119,7 @@ contract Cooler is Clone {
         );
 
         // Log the event.
-        factory().newEvent(reqID, CoolerFactory.Events.RequestLoan, 0);
+        factory().logRequestLoan(reqID);
     }
 
     /// @notice Cancel a loan request and get the collateral back.
@@ -136,7 +136,7 @@ contract Cooler is Clone {
         collateral().safeTransfer(owner(), collateralFor(req.amount, req.loanToCollateral));
 
         // Log the event.
-        factory().newEvent(reqID_, CoolerFactory.Events.RescindRequest, 0);
+        factory().logRescindRequest(reqID_);
     }
 
     /// @notice Repay a loan to get the collateral back.
@@ -184,34 +184,12 @@ contract Cooler is Clone {
         if (decollateralized > 0) collateral().safeTransfer(owner(), decollateralized);
 
         // Log the event.
-        factory().newEvent(loanID_, CoolerFactory.Events.RepayLoan, repayment_);
+        factory().logRepayLoan(loanID_, repayment_);
 
         // If necessary, trigger lender callback.
         if (loan.callback) CoolerCallback(loan.lender).onRepay(loanID_, remainder, interestPaid);
 
         return decollateralized;
-    }
-
-    // Allow lender to extend loan for borrower. Any payments are done by the caller.
-    function extendLoanTerms(uint256 loanID_, uint8 times_) external {
-        Loan memory loan = loans[loanID_];
-
-        if (msg.sender != loan.lender) revert OnlyApproved();
-        if (block.timestamp > loan.expiry) revert Default();
-
-        // Update loan terms to reflect the extension.
-        loan.expiry += loan.request.duration * times_;
-        loan.interestDue = interestFor(
-            loan.request.amount,
-            loan.request.interest,
-            loan.request.duration
-        );
-
-        // Save updated loan info in storage.
-        loans[loanID_] = loan;
-
-        // Log the event.
-        factory().newEvent(loanID_, CoolerFactory.Events.ExtendLoan, 0);
     }
 
     /// @notice Delegate voting power on collateral.
@@ -269,7 +247,29 @@ contract Cooler is Clone {
         debt().safeTransferFrom(msg.sender, owner(), req.amount);
 
         // Log the event.
-        factory().newEvent(reqID_, CoolerFactory.Events.ClearRequest, 0);
+        factory().logClearRequest(reqID_, loanID);
+    }
+
+    // Allow lender to extend loan for borrower. Any payments are done by the caller.
+    function extendLoanTerms(uint256 loanID_, uint8 times_) external {
+        Loan memory loan = loans[loanID_];
+
+        if (msg.sender != loan.lender) revert OnlyApproved();
+        if (block.timestamp > loan.expiry) revert Default();
+
+        // Update loan terms to reflect the extension.
+        loan.expiry += loan.request.duration * times_;
+        loan.interestDue = interestFor(
+            loan.request.amount,
+            loan.request.interest,
+            loan.request.duration
+        );
+
+        // Save updated loan info in storage.
+        loans[loanID_] = loan;
+
+        // Log the event.
+        factory().logExtendLoan(loanID_, times_);
     }
 
     /// @notice Claim collateral upon loan default.
@@ -285,7 +285,7 @@ contract Cooler is Clone {
         collateral().safeTransfer(loan.lender, loan.collateral);
 
         // Log the event.
-        factory().newEvent(loanID_, CoolerFactory.Events.DefaultLoan, 0);
+        factory().logDefaultLoan(loanID_);
 
         // If necessary, trigger lender callback.
         if (loan.callback)

--- a/src/CoolerFactory.sol
+++ b/src/CoolerFactory.sol
@@ -13,20 +13,24 @@ import {Cooler} from "./Cooler.sol";
 contract CoolerFactory {
     using ClonesWithImmutableArgs for address;
 
+    // --- ERRORS ----------------------------------------------------
+
+    error OnlyFromFactory();
+
     // --- EVENTS ----------------------------------------------------
 
-    /// @notice A global event when a new loan request is created.
-    event RequestLoan(address cooler, address collateral, address debt, uint256 reqID);
-    /// @notice A global event when a loan request is rescinded.
-    event RescindRequest(address cooler, uint256 reqID);
-    /// @notice A global event when a loan request is fulfilled.
-    event ClearRequest(address cooler, uint256 reqID);
-    /// @notice A global event when a loan is repaid.
-    event RepayLoan(address cooler, uint256 loanID, uint256 amount);
-    /// @notice A global event when a loan is extended.
-    event ExtendLoan(address cooler, uint256 loanID);
-    /// @notice A global event when the collateral of defaulted loan is claimed.
-    event DefaultLoan(address cooler, uint256 loanID);
+    /// @notice Emit a global event when a new loan request is created.
+    event RequestLoan(address indexed cooler, address collateral, address debt, uint256 reqID);
+    /// @notice Emit a global event when a loan request is rescinded.
+    event RescindRequest(address indexed cooler, uint256 reqID);
+    /// @notice Emit a global event when a loan request is fulfilled.
+    event ClearRequest(address indexed cooler, uint256 reqID, uint256 loanID);
+    /// @notice Emit a global event when a loan is repaid.
+    event RepayLoan(address indexed cooler, uint256 loanID, uint256 amount);
+    /// @notice Emit a global event when a loan is extended.
+    event ExtendLoan(address indexed cooler, uint256 loanID, uint8 times);
+    /// @notice Emit a global event when the collateral of defaulted loan is claimed.
+    event DefaultLoan(address indexed cooler, uint256 loanID);
 
     // -- STATE VARIABLES --------------------------------------------
 
@@ -79,34 +83,39 @@ contract CoolerFactory {
 
     // --- EMIT EVENTS -----------------------------------------------
 
-    enum Events {
-        RequestLoan,
-        RescindRequest,
-        ClearRequest,
-        RepayLoan,
-        ExtendLoan,
-        DefaultLoan
+    /// @notice Ensure that the called is a Cooler.
+    modifier onlyFromFactory {        
+        if (!created[msg.sender]) revert OnlyFromFactory();
+        _;
     }
 
-    /// @notice emit an event each time a request is interacted with on a Cooler.
-    /// @param  id_ loan or request identifier.
-    /// @param  ev_ event type.
-    /// @param  amount_ to be logged by the event.
-    function newEvent(uint256 id_, Events ev_, uint256 amount_) external {
-        require(created[msg.sender], "Only Created");
+    /// @notice Emit a global event when a new loan request is created.
+    function logRequestLoan(uint256 reqID_) external onlyFromFactory {
+        emit RequestLoan(msg.sender, address(Cooler(msg.sender).collateral()), address(Cooler(msg.sender).debt()), reqID_);
+    }
 
-        if (ev_ == Events.RequestLoan) {
-            emit RequestLoan(msg.sender, address(Cooler(msg.sender).collateral()), address(Cooler(msg.sender).debt()), id_);
-        } else if (ev_ == Events.RescindRequest) {
-            emit RescindRequest(msg.sender, id_);
-        } else if (ev_ == Events.ClearRequest) {
-            emit ClearRequest(msg.sender, id_);
-        } else if (ev_ == Events.RepayLoan) {
-            emit RepayLoan(msg.sender, id_, amount_);
-        } else if (ev_ == Events.ExtendLoan) {
-            emit ExtendLoan(msg.sender, id_);
-        } else if (ev_ == Events.DefaultLoan) {
-            emit DefaultLoan(msg.sender, id_);
-        }
+    /// @notice Emit a global event when a loan request is rescinded.
+    function logRescindRequest(uint256 reqID_) external onlyFromFactory {
+        emit RescindRequest(msg.sender, reqID_);
+    }
+
+    /// @notice Emit a global event when a loan request is fulfilled.
+    function logClearRequest(uint256 reqID_, uint256 loanID_) external onlyFromFactory {
+        emit ClearRequest(msg.sender, reqID_, loanID_);
+    }
+
+    /// @notice Emit a global event when a loan is repaid.
+    function logRepayLoan(uint256 loanID_, uint256 repayment_) external onlyFromFactory {
+        emit RepayLoan(msg.sender, loanID_, repayment_);
+    }
+
+    /// @notice Emit a global event when a loan is extended.
+    function logExtendLoan(uint256 loanID_, uint8 times_) external onlyFromFactory {
+        emit ExtendLoan(msg.sender, loanID_, times_);
+    }
+
+    /// @notice Emit a global event when the collateral of defaulted loan is claimed.
+    function logDefaultLoan(uint256 loanID_) external onlyFromFactory {
+        emit DefaultLoan(msg.sender, loanID_);
     }
 }

--- a/src/CoolerFactory.sol
+++ b/src/CoolerFactory.sol
@@ -19,17 +19,17 @@ contract CoolerFactory {
 
     // --- EVENTS ----------------------------------------------------
 
-    /// @notice Emit a global event when a new loan request is created.
+    /// @notice A global event when a new loan request is created.
     event RequestLoan(address indexed cooler, address collateral, address debt, uint256 reqID);
-    /// @notice Emit a global event when a loan request is rescinded.
+    /// @notice A global event when a loan request is rescinded.
     event RescindRequest(address indexed cooler, uint256 reqID);
-    /// @notice Emit a global event when a loan request is fulfilled.
+    /// @notice A global event when a loan request is fulfilled.
     event ClearRequest(address indexed cooler, uint256 reqID, uint256 loanID);
-    /// @notice Emit a global event when a loan is repaid.
+    /// @notice A global event when a loan is repaid.
     event RepayLoan(address indexed cooler, uint256 loanID, uint256 amount);
-    /// @notice Emit a global event when a loan is extended.
+    /// @notice A global event when a loan is extended.
     event ExtendLoan(address indexed cooler, uint256 loanID, uint8 times);
-    /// @notice Emit a global event when the collateral of defaulted loan is claimed.
+    /// @notice A global event when the collateral of defaulted loan is claimed.
     event DefaultLoan(address indexed cooler, uint256 loanID);
 
     // -- STATE VARIABLES --------------------------------------------

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -86,8 +86,8 @@ contract ClearinghouseTest is Test {
     uint256 internal initialSDai;
 
     // Clearinghouse Expected events
-    event Defund();
-    event Rebalance();
+    event Defund(int256 amount);
+    event Rebalance(int256 amount);
     event Deactivate();
     event Reactivate();
 
@@ -436,7 +436,7 @@ contract ClearinghouseTest is Test {
 
         // Ensure that the event is emitted
         vm.expectEmit(address(clearinghouse));
-        emit Rebalance();
+        emit Rebalance(int256(sdai.previewWithdraw(oneMillion)));
         // Rebalance
         clearinghouse.rebalance();
 
@@ -487,6 +487,10 @@ contract ClearinghouseTest is Test {
         uint256 daiInitTRSRY = sdai.maxWithdraw(address(TRSRY));
         uint256 sdaiInitTRSRY = sdai.balanceOf(address(TRSRY));
 
+        // Ensure that the event is emitted
+        vm.expectEmit(address(clearinghouse));
+        emit Rebalance(- int256(sdai.previewWithdraw(oneMillion)));
+        // Rebalance
         clearinghouse.rebalance();
 
         assertEq(daiInitTRSRY + oneMillion, sdai.maxWithdraw(address(TRSRY)), "DAI balance TRSRY");
@@ -561,7 +565,7 @@ contract ClearinghouseTest is Test {
 
         // Ensure that the event is emitted
         vm.expectEmit(address(clearinghouse));
-        emit Defund();
+        emit Defund(address(sdai), - int256(sdai.previewRedeem(1e24)));
         // Defund
         vm.prank(overseer);
         clearinghouse.defund(sdai, 1e24);

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -86,7 +86,7 @@ contract ClearinghouseTest is Test {
     uint256 internal initialSDai;
 
     // Clearinghouse Expected events
-    event Defund(int256 amount);
+    event Defund(address token, int256 amount);
     event Rebalance(int256 amount);
     event Deactivate();
     event Reactivate();

--- a/src/test/CoolerFactory.t.sol
+++ b/src/test/CoolerFactory.t.sol
@@ -29,12 +29,12 @@ contract CoolerFactoryTest is Test {
     CoolerFactory internal coolerFactory;
 
     // CoolerFactory Expected events
-    event RequestLoan(address cooler, address collateral, address debt, uint256 reqID);
-    event RescindRequest(address cooler, uint256 reqID);
-    event ClearRequest(address cooler, uint256 reqID);
-    event RepayLoan(address cooler, uint256 loanID, uint256 amount);
-    event ExtendLoan(address cooler, uint256 loanID);
-    event DefaultLoan(address cooler, uint256 loanID);
+    event RequestLoan(address indexed cooler, address collateral, address debt, uint256 reqID);
+    event RescindRequest(address indexed cooler, uint256 reqID);
+    event ClearRequest(address indexed cooler, uint256 reqID, uint256 loanID);
+    event RepayLoan(address indexed cooler, uint256 loanID, uint256 amount);
+    event ExtendLoan(address indexed cooler, uint256 loanID, uint8 times);
+    event DefaultLoan(address indexed cooler, uint256 loanID);
 
     function setUp() public {
         vm.warp(51 * 365 * 24 * 60 * 60); // Set timestamp at roughly Jan 1, 2021 (51 years since Unix epoch)
@@ -82,44 +82,44 @@ contract CoolerFactoryTest is Test {
     function test_newEvent() public {
         uint256 id = 0;
         uint256 amount = 1234;
+        uint8 times = 1;
 
         vm.prank(alice);
         address cooler = coolerFactory.generateCooler(collateral, debt);
 
         vm.startPrank(cooler);
         // Request Event
-        vm.expectEmit(true, true, true, true);
+        vm.expectEmit(address(coolerFactory));
         emit RequestLoan(cooler, address(collateral), address(debt), id);
-        coolerFactory.newEvent(id, CoolerFactory.Events.RequestLoan, amount);
+        coolerFactory.logRequestLoan(id);
         // Rescind Event
-        vm.expectEmit(true, true, false, false);
+        vm.expectEmit(address(coolerFactory));
         emit RescindRequest(cooler, id);
-        coolerFactory.newEvent(id, CoolerFactory.Events.RescindRequest, amount);
+        coolerFactory.logRescindRequest(id);
         // Clear Event
-        vm.expectEmit(true, true, false, false);
-        emit ClearRequest(cooler, id);
-        coolerFactory.newEvent(id, CoolerFactory.Events.ClearRequest, amount);
+        vm.expectEmit(address(coolerFactory));
+        emit ClearRequest(cooler, id, id);
+        coolerFactory.logClearRequest(id, id);
         // Repay Event
-        vm.expectEmit(true, true, true, false);
+        vm.expectEmit(address(coolerFactory));
         emit RepayLoan(cooler, id, amount);
-        coolerFactory.newEvent(id, CoolerFactory.Events.RepayLoan, amount);
+        coolerFactory.logRepayLoan(id, amount);
         // Extend Event
-        vm.expectEmit(true, true, false, false);
-        emit ExtendLoan(cooler, id);
-        coolerFactory.newEvent(id, CoolerFactory.Events.ExtendLoan, amount);
+        vm.expectEmit(address(coolerFactory));
+        emit ExtendLoan(cooler, id, times);
+        coolerFactory.logExtendLoan(id, times);
         // Default Event
-        vm.expectEmit(true, true, false, false);
+        vm.expectEmit(address(coolerFactory));
         emit DefaultLoan(cooler, id);
-        coolerFactory.newEvent(id, CoolerFactory.Events.DefaultLoan, amount);
+        coolerFactory.logDefaultLoan(id);
     }
 
     function testRevert_newEvent() public {
         uint256 id = 0;
-        uint256 amount = 1234;
 
         // Only coolers can emit events
         vm.prank(alice);
-        vm.expectRevert("Only Created");
-        coolerFactory.newEvent(id, CoolerFactory.Events.ClearRequest, amount);
+        vm.expectRevert(CoolerFactory.OnlyFromFactory.selector);
+        coolerFactory.logRequestLoan(id);
     }
 }


### PR DESCRIPTION
- Cooler:
   - [x] Don't delete loan entries > done in https://github.com/ohmzeus/Cooler/pull/47 as an audit remediation
   - [X] Emit loan id and request id both when clearing a loan request
   - [X] ~~Emit newDebt and newCollateral for rollover loan event~~ > extensions will always incur the same interest due (proportional to the times rolled).
   - [X] Emit an event for ~~rollover~~ extended loan
  
- Clearinghouse:
   - [X] Emit event when a rebalance occurs
   - [X] Emit event when a defunding occurs
   - [ ] Add amounts to the events (regular integers instead of unsigned)