### PR TITLE
fix: low / informational issues from the audit

### DIFF
--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -286,15 +286,9 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
             : 0;
     }
     
-    /// @notice Ensure gOHM is burnt if default happens through the Cooler.
-    function _onDefault(uint256, uint256, uint256, uint256) internal override {
-        uint256 gohmBalance = gohm.balanceOf(address(this));
-        if (gohmBalance != 0) {
-            // Unstake and burn the collateral of the defaulted loans.
-            gohm.approve(address(staking), gohmBalance);
-            MINTR.burnOhm(address(this), staking.unstake(address(this), gohmBalance, false, false));
-        }
-    }
+    /// @notice Unused callback since defaults are handled by the clearinghouse.
+    /// @dev Overriden and left empty to save gas.
+    function _onDefault(uint256, uint256, uint256, uint256) internal override {}
 
     // --- FUNDING ---------------------------------------------------
 
@@ -393,6 +387,15 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
         }
 
         token_.transfer(address(TRSRY), amount_);
+    }
+
+    /// @notice Burn any gOHM defaulted using the Cooler instead of the Clearinghouse.
+    function burn() external {
+        uint256 gohmBalance = gohm.balanceOf(address(this));
+
+        // Unstake and burn gOHM holdings.
+        gohm.approve(address(staking), gohmBalance);
+        MINTR.burnOhm(address(this), staking.unstake(address(this), gohmBalance, false, false));
     }
 
     /// @notice Deactivate the contract and return funds to treasury.

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -321,6 +321,8 @@ contract Cooler is Clone {
         // Update the load lender and the recipient.
         loans[loanID_].lender = msg.sender;
         loans[loanID_].recipient = msg.sender;
+        // Callbacks are disabled when transferring ownership.
+        loans[loanID_].callback = false;
         // Clear transfer approvals.
         approvals[loanID_] = address(0);
     }

--- a/src/CoolerFactory.sol
+++ b/src/CoolerFactory.sol
@@ -15,6 +15,7 @@ contract CoolerFactory {
 
     // --- ERRORS ----------------------------------------------------
 
+    error NotFromFactory();
     error DecimalsNot18();
 
     // --- EVENTS ----------------------------------------------------
@@ -65,7 +66,7 @@ function generateCooler(ERC20 collateral_, ERC20 debt_) external returns (addres
 
     // Otherwise generate new cooler.
     if (cooler == address(0)) {
-        if (collateral_.decimals() != 18 || collateral_.decimals() != 18) revert DecimalsNot18();
+        if (collateral_.decimals() != 18 || debt_.decimals() != 18) revert DecimalsNot18();
         // Clone the cooler implementation.
         bytes memory coolerData = abi.encodePacked(
             msg.sender,              // owner
@@ -98,7 +99,7 @@ function generateCooler(ERC20 collateral_, ERC20 debt_) external returns (addres
     /// @param  ev_ event type.
     /// @param  amount_ to be logged by the event.
     function newEvent(uint256 id_, Events ev_, uint256 amount_) external {
-        require(created[msg.sender], "Only Created");
+        if (!created[msg.sender]) revert NotFromFactory();
 
         if (ev_ == Events.RequestLoan) {
             emit RequestLoan(msg.sender, address(Cooler(msg.sender).collateral()), address(Cooler(msg.sender).debt()), id_);

--- a/src/test/Cooler.t.sol
+++ b/src/test/Cooler.t.sol
@@ -977,44 +977,4 @@ contract CoolerTest is Test {
         vm.expectRevert(Cooler.Default.selector);
         cooler.extendLoanTerms(loanID, 1);
     }
-
-    function test_collateralFor_debtDecimalsHigh() public {
-        uint8 collateralDecimals = 6;   // collateral: USDC
-        uint8 debtDecimals = 18;        // debt: WETH
-
-        // Both values are in terms of debt decimals
-        uint256 loanToCollateral_ = (10 ** collateralDecimals) * 1e18 / 2000e6; // 1 WETH : 2000 USDC
-        uint256 amount_ = 1e18;
-
-        // Create the tokens
-        collateral = new MockGohm("Collateral", "COL", collateralDecimals);
-        debt = new MockERC20("Debt", "DEBT", debtDecimals);
-
-        // Instantiate a new cooler
-        cooler = _initCooler();
-
-        // collateralFor() should return the correct amount of collateral tokens
-        uint256 collateralFor = cooler.collateralFor(amount_, loanToCollateral_);
-        assertEq(collateralFor, 2000e6, "USDC");
-    }
-
-    function test_collateralFor_debtDecimalsLow() public {
-        uint8 collateralDecimals = 18;  // collateral: WETH
-        uint8 debtDecimals = 6;         // debt: USDC
-
-        // Both values are in terms of debt decimals
-        uint256 loanToCollateral_ = (10 ** collateralDecimals) * 2000e6 / 1e18; // 2000 USDC : 1 WETH
-        uint256 amount_ = 2000e6;
-
-        // Create the tokens
-        collateral = new MockGohm("Collateral", "COL", collateralDecimals);
-        debt = new MockERC20("Debt", "DEBT", debtDecimals);
-
-        // Instantiate a new cooler
-        cooler = _initCooler();
-
-        // collateralFor() should return the correct amount of collateral tokens
-        uint256 collateralFor = cooler.collateralFor(amount_, loanToCollateral_);
-        assertEq(collateralFor, 1e18, "ETH");
-    }
 }

--- a/src/test/CoolerFactory.t.sol
+++ b/src/test/CoolerFactory.t.sol
@@ -79,6 +79,25 @@ contract CoolerFactoryTest is Test {
         assertEq(otherCoolerBob, coolerFactory.coolersFor(collateral, otherDebt, 0));
     }
 
+    function testRevert_wrongDecimals() public {
+        // Create the wrong tokens
+        MockERC20 wrongCollateral = new MockERC20("Collateral", "COL", 6);
+        MockERC20 wrongDebt = new MockERC20("Debt", "DEBT", 6);
+
+        // Only tokens with 18 decimals are allowed
+        vm.startPrank(alice);
+
+        // Collateral with 6 decimals
+        vm.expectRevert(CoolerFactory.DecimalsNot18.selector);
+        coolerFactory.generateCooler(wrongCollateral, debt);
+        // Debt with 6 decimals        
+        vm.expectRevert(CoolerFactory.DecimalsNot18.selector);
+        coolerFactory.generateCooler(collateral, wrongDebt);
+        // Both with 6 decimals
+        vm.expectRevert(CoolerFactory.DecimalsNot18.selector);
+        coolerFactory.generateCooler(wrongCollateral, wrongDebt);
+    }
+
     function test_newEvent() public {
         uint256 id = 0;
         uint256 amount = 1234;
@@ -119,7 +138,7 @@ contract CoolerFactoryTest is Test {
 
         // Only coolers can emit events
         vm.prank(alice);
-        vm.expectRevert("Only Created");
+        vm.expectRevert(CoolerFactory.NotFromFactory.selector);
         coolerFactory.newEvent(id, CoolerFactory.Events.ClearRequest, amount);
     }
 }


### PR DESCRIPTION
- add `burn` function to handle gOHM in the unlikely case that someone defaults via Cooler instead of Clearinghouse.
- rename `isDefaulted` to `isExpired`.
- disable callbacks when lender ownership rights are transferred.
- ensure Coolers only work with 18 decimal tokens.