### PR TITLE
fix: extension design to make it fully trustless

### DIFF
--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -185,12 +185,8 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
         // Ensure Clearinghouse is the lender.
         if (loan.lender != address(this)) revert NotLender();
 
+        // Calculate extension interest based on remaining principal.
         uint256 interestBase = interestForLoan(loan.principal, loan.request.duration);
-        if (loan.interestDue != interestBase) {
-            // If interest has manually been repaid, receivables need to be updated
-            interestReceivables += interestBase - loan.interestDue;
-        }
-
         // Transfer in extension interest from the caller.
         dai.transferFrom(msg.sender, loan.recipient, interestBase * times_);
 

--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -185,19 +185,14 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
         // Ensure Clearinghouse is the lender.
         if (loan.lender != address(this)) revert NotLender();
 
-        uint256 interestNew;
         uint256 interestBase = interestForLoan(loan.principal, loan.request.duration);
         if (loan.interestDue != interestBase) {
-            // If interest has manually been repaid, user only pays for the subsequent extensions.
-            interestNew = interestBase * (times_ - 1) + loan.interestDue;
-            // Receivables need to be updated.
+            // If interest has manually been repaid, receivables need to be updated
             interestReceivables += interestBase - loan.interestDue;
-        } else {
-            // Otherwise, user pays for all the extensions.
-            interestNew = interestBase * times_;
         }
+
         // Transfer in extension interest from the caller.
-        dai.transferFrom(msg.sender, loan.recipient, interestNew);
+        dai.transferFrom(msg.sender, loan.recipient, interestBase * times_);
 
         // Signal to cooler that loan can be extended.
         cooler_.extendLoanTerms(loanID_, times_);

--- a/src/Clearinghouse.sol
+++ b/src/Clearinghouse.sol
@@ -173,6 +173,8 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
     }
 
     /// @notice Extend the loan expiry by repaying the extension interest in advance.
+    ///         The extension cost is paid by the caller. If a third-party executes the
+    ///         extension, the loan period is extended, but the borrower debt does not increase.
     /// @param  cooler_ holding the loan to be extended.
     /// @param  loanID_ index of loan in loans[].
     /// @param  times_ Amount of times that the fixed-term loan duration is extended.
@@ -185,7 +187,7 @@ contract Clearinghouse is Policy, RolesConsumer, CoolerCallback {
         // Ensure Clearinghouse is the lender.
         if (loan.lender != address(this)) revert NotLender();
 
-        // Calculate extension interest based on remaining principal.
+        // Calculate extension interest based on the remaining principal.
         uint256 interestBase = interestForLoan(loan.principal, loan.request.duration);
         // Transfer in extension interest from the caller.
         dai.transferFrom(msg.sender, loan.recipient, interestBase * times_);

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -256,9 +256,10 @@ contract Cooler is Clone {
         factory().logClearRequest(reqID_, loanID);
     }
 
-    /// @notice Allow lender to extend a loan for the borrower.
-    /// @dev    Since this function solely impacts the expiration day and resets the interest due,
-    ///         The lender should ensure that repayments are done to them beforehand.
+    /// @notice Allow lender to extend a loan for the borrower. Doesn't require
+    ///         borrower permission because it doesn't have a negative impact for them.
+    /// @dev    Since this function solely impacts the expiration day, the lender
+    ///         should ensure that extension interest payments are done beforehand.
     /// @param  loanID_ index of loan in loans[].
     /// @param  times_ that the fixed-term loan duration is extended.
     function extendLoanTerms(uint256 loanID_, uint8 times_) external {

--- a/src/Cooler.sol
+++ b/src/Cooler.sol
@@ -23,7 +23,6 @@ contract Cooler is Clone {
     error Deactivated();
     error Default();
     error NotExpired();
-    error NotExtension();
     error NotCoolerCallback();
 
     // --- DATA STRUCTURES -------------------------------------------
@@ -267,15 +266,9 @@ contract Cooler is Clone {
 
         if (msg.sender != loan.lender) revert OnlyApproved();
         if (block.timestamp > loan.expiry) revert Default();
-        if (times_ == 0) revert NotExtension();
 
         // Update loan terms to reflect the extension.
         loan.expiry += loan.request.duration * times_;
-        loan.interestDue = interestFor(
-            loan.request.amount,
-            loan.request.interest,
-            loan.request.duration
-        );
 
         // Save updated loan info in storage.
         loans[loanID_] = loan;

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -373,7 +373,7 @@ contract ClearinghouseTest is Test {
         uint256 initInterest = clearinghouse.interestReceivables();
         uint256 initPrincipal = clearinghouse.principalReceivables();
         // Approve the interest of the followup extensions
-        uint256 interestOwed = clearinghouse.interestForLoan(initLoan.principal, initLoan.request.duration) * (times_ - 1) + repaidLoan.interestDue;
+        uint256 interestOwed = clearinghouse.interestForLoan(initLoan.principal, initLoan.request.duration) * times_;
         dai.approve(address(clearinghouse), interestOwed);
 
         // Extend loan
@@ -386,12 +386,12 @@ contract ClearinghouseTest is Test {
         assertEq(dai.balanceOf(user), initDaiUser - interestOwed, "DAI user");
         assertEq(dai.balanceOf(address(clearinghouse)), initDaiCH + interestOwed, "DAI CH");
         // Check: cooler storage
-        assertEq(extendedLoan.principal, initLoan.principal, "principal");
-        assertEq(extendedLoan.interestDue, initLoan.interestDue, "interest");
-        assertEq(extendedLoan.collateral, initLoan.collateral, "collateral");
-        assertEq(extendedLoan.expiry, initLoan.expiry + initLoan.request.duration * times_, "expiry");
+        assertEq(extendedLoan.principal, repaidLoan.principal, "principal");
+        assertEq(extendedLoan.interestDue, repaidLoan.interestDue, "interest");
+        assertEq(extendedLoan.collateral, repaidLoan.collateral, "collateral");
+        assertEq(extendedLoan.expiry, repaidLoan.expiry + repaidLoan.request.duration * times_, "expiry");
         // Check: clearinghouse storage
-        assertEq(clearinghouse.interestReceivables(), initInterest + extendedLoan.interestDue - repaidLoan.interestDue);
+        assertEq(clearinghouse.interestReceivables(), initInterest + initLoan.interestDue - repaidLoan.interestDue);
         assertEq(clearinghouse.principalReceivables(), initPrincipal);
     }
 

--- a/src/test/Clearinghouse.t.sol
+++ b/src/test/Clearinghouse.t.sol
@@ -391,7 +391,7 @@ contract ClearinghouseTest is Test {
         assertEq(extendedLoan.collateral, repaidLoan.collateral, "collateral");
         assertEq(extendedLoan.expiry, repaidLoan.expiry + repaidLoan.request.duration * times_, "expiry");
         // Check: clearinghouse storage
-        assertEq(clearinghouse.interestReceivables(), initInterest + initLoan.interestDue - repaidLoan.interestDue);
+        assertEq(clearinghouse.interestReceivables(), initInterest);
         assertEq(clearinghouse.principalReceivables(), initPrincipal);
     }
 


### PR DESCRIPTION
- Doesn't modify `interestDue` when extending, so that extensions can't have any negative impact on borrowers.